### PR TITLE
Add shared docs layout includes: sidenav, on-this-page TOC, post sect…

### DIFF
--- a/_includes/audio.html
+++ b/_includes/audio.html
@@ -1,0 +1,31 @@
+{% if audio %}
+  <div class="border px-4 py-2 shadow">
+    <h2 class="h4 my-0 py-3">Listen
+      <i class="fa-solid fa-volume-high" aria-hidden="true"></i>
+    </h2>
+    <p class="pb-0 small text-secondary mb-0 pb-3">A podcast overview of
+      {% if lowercase == true %}
+        {{ title | lower }}
+      {% else %}
+        {{ title }}
+      {% endif %}
+      made with Google NotebookLM.</p>
+    <script src="/js/plyr.js"></script>
+    <audio id="player" controls>
+      <source src="{{ site.url }}/assets/audio/{{ audio }}" type="audio/mp3">
+      <source src="{{ audio }}" type="audio/mp3">
+    </audio>
+    <script>
+                const plyr = new Plyr('audio', {
+                    controls: [
+                        'play',
+                        'progress',
+                        'current-time',
+                        'duration',
+                        'mute',
+                        'volume'
+                    ]
+                });
+    </script>
+  </div>
+{% endif %}

--- a/_includes/image.html
+++ b/_includes/image.html
@@ -1,0 +1,18 @@
+{% if imgOg %}
+  <figure class="mb-5">
+    <img src="/assets/img/posts/{{ imgOg }}" alt="{{ imgAlt }}" type="{{ folder }}" class="border img-fluid">
+    {% if imgCaption %}
+      <figcaption>
+        <p class="small mt-3 mb-4 pb-3 border-bottom">
+          {% if imgLink %}
+            <a href="{{ imgLink }}" class="text-body-secondary link-body-emphasis link-offset-3">
+          {% endif %}
+          {{ imgCaption }}
+          {% if imgLink %}
+            </a>
+          {% endif %}
+        </p>
+      </figcaption>
+    {% endif %}
+  </figure>
+{% endif %}

--- a/_includes/layouts/docs.html
+++ b/_includes/layouts/docs.html
@@ -1,0 +1,31 @@
+{% include "header.html" %}
+{% include "nav.html" %}
+<main id="main-content">
+  <article>
+    <div class="container-fluid mt-3">
+      <div class="row g-4">
+        <div class="col-12 col-md-2">
+          {% include "sidenav.html" %}
+        </div>
+        <div class="col-12 col-md-8">
+          <div id="post">
+            {% include "post-badges.html" %}
+            {% if title %}<h1 class="pb-2">{{ title | safe }}</h1>{% endif %}
+            {% if description %}<p class="lead fs-4 pb-3 mb-4 border-bottom">{{ description | safe }}</p>{% endif %}
+            {% include "toc-mobile.html" %}
+            {% include "scangov.html" %}
+            {% include "image.html" %}
+            {% include "audio.html" %}
+            {{ content | safe }}
+            {% include "post-links.html" %}
+            {% include "related.html" %}
+          </div>
+        </div>
+        <div class="col-12 col-md-2">
+          {% include "toc.html" %}
+        </div>
+      </div>
+    </div>
+  </article>
+</main>
+{% include "footer.html" %}

--- a/_includes/post-badges.html
+++ b/_includes/post-badges.html
@@ -1,0 +1,16 @@
+{% if isStandard %}
+  <div class="mb-4">
+    <a href="/" class="btn btn-primary-outline">
+      <i class="fa-solid fa-certificate" aria="hidden"></i>
+      Standard
+    </a>
+  </div>
+{% endif %}
+{% if isGuidance %}
+  <div class="mb-4">
+    <a href="/guidance" class="btn btn-primary-outline">
+      <i class="fa-solid fa-scroll" aria="hidden"></i>
+      Guidance
+    </a>
+  </div>
+{% endif %}

--- a/_includes/post-links.html
+++ b/_includes/post-links.html
@@ -1,0 +1,18 @@
+{% if website %}
+  <ul class="list-unstyled">
+{% endif %}
+{% if website %}
+  <li>
+    <i class="fa-solid fa-laptop"></i>
+    <a href="{{ website }}" class="">Website</a>
+  </li>
+{% endif %}
+{% if org %}
+  <li class="mt-2">
+    <i class="fa-solid fa-building"></i>
+    <a href="{{ orgLink }}" class="">{{ org }}</a>
+  </li>
+{% endif %}
+{% if website %}
+  </ul>
+{% endif %}

--- a/_includes/related.html
+++ b/_includes/related.html
@@ -1,0 +1,44 @@
+{% set related_pages = [] %}
+{% if topics %}
+  {% for other_page in collections.pages %}
+    {% if other_page.url != page.url and other_page.data.topics %}
+      {% for topic in topics %}
+        {% if topic in other_page.data.topics %}
+          {% set related_pages = (related_pages.push(other_page), related_pages) %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+{% if related_pages.length > 0 %}
+  <h2 class="mt-5">Related</h2>
+  <ul>
+    {% for related in related_pages %}
+      {% if loop.index <= 5 %}
+        {% if related.data.title != "Services" and "ScanGov" not in related.data.title %}
+          <li>
+            <a href="{{ related.url }}">{{ related.data.title }}</a>
+          </li>
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+  </ul>
+{% endif %}
+{% set shown_topics = [] %}
+{% for topic in collections.topics %}
+  {% if topic.data.link and topic.data.title in topics %}
+    {% set shown_topics = (shown_topics.push(topic), shown_topics) %}
+  {% endif %}
+{% endfor %}
+
+{% if shown_topics.length > 0 %}
+  <h2 class="mt-5">ScanGov</h2>
+  <p>Grades/scores that use {{ title }}:</p>
+  <ul>
+    {% for topic in shown_topics %}
+      <li>
+        <a href="{{ topic.data.link }}">{{ topic.data.title }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+{% endif %}

--- a/_includes/scangov.html
+++ b/_includes/scangov.html
@@ -1,0 +1,9 @@
+{% if scangov == true %}
+  <div class="alert alert-info shadow mt-0 mb-4">
+    <p class="m-0 p-0">
+      <i class="fa-solid fa-asterisk" aria-label="hidden"></i>
+      This feature is available to
+      <a href="https://scangov.com">ScanGov</a>
+      customers.</p>
+  </div>
+{% endif %}

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,0 +1,24 @@
+<nav class="d-none d-md-block js-sidenav position-sticky" style="top: 1rem;">
+  <ul class="nav flex-column small">
+    {% for item in sidenav %}
+      {% if item.items %}
+        <li class="nav-item mt-3 mb-1 text-uppercase text-secondary fw-bold">
+          {% if item.icon %}<i class="{{ item.icon }} me-2 fa-fw"></i>{% endif %}{{ item.title }}
+        </li>
+        {% for sub in item.items %}
+          <li class="nav-item mb-0 border-bottom">
+            <a href="{{ sub.url }}" class="text-body text-decoration-none d-block py-2 ps-3{% if page.url == sub.url %} fw-bold{% endif %}">
+              {% if sub.icon %}<i class="{{ sub.icon }} me-2 fa-fw"></i>{% endif %}{{ sub.title }}
+            </a>
+          </li>
+        {% endfor %}
+      {% else %}
+        <li class="nav-item mb-0 border-bottom">
+          <a href="{{ item.url }}" class="text-body text-decoration-none d-block py-2{% if page.url == item.url %} fw-bold{% endif %}">
+            {% if item.icon %}<i class="{{ item.icon }} me-2 fa-fw"></i>{% endif %}{{ item.title }}
+          </a>
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+</nav>

--- a/_includes/toc-mobile.html
+++ b/_includes/toc-mobile.html
@@ -1,0 +1,5 @@
+<div class="d-none js-on-this-page js-on-this-page-mobile mb-4">
+  <p class="border-bottom pb-3">On this page</p>
+  <ul class="nav flex-column">
+  </ul>
+</div>

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,0 +1,33 @@
+<div class="d-none js-on-this-page js-on-this-page-desktop">
+  <p class="border-bottom pb-3">On this page</p>
+  <ul class="nav flex-column">
+  </ul>
+</div>
+<script>
+  const headings = document.querySelectorAll('#post h2, #post h3');
+  if (headings.length > 0) {
+    document.querySelectorAll('.js-on-this-page ul').forEach(function (tocContainer) {
+      headings.forEach(function (heading) {
+        const li = document.createElement('li');
+        li.className = 'mb-2 small';
+        if (heading.tagName === 'H3') {
+          li.classList.add('ms-3');
+        }
+        const a = document.createElement('a');
+        a.href = '#' + heading.id;
+        a.textContent = heading.textContent.replace(/\s+/g, ' ').trim();
+        li.appendChild(a);
+        tocContainer.appendChild(li);
+      });
+    });
+    const mobileToc = document.querySelector('.js-on-this-page-mobile');
+    if (mobileToc) {
+      mobileToc.classList.remove('d-none');
+      mobileToc.classList.add('d-md-none');
+    }
+    const desktopToc = document.querySelector('.js-on-this-page-desktop');
+    if (desktopToc) {
+      desktopToc.classList.add('d-md-block');
+    }
+  }
+</script>

--- a/public/css/scangov.css
+++ b/public/css/scangov.css
@@ -1842,6 +1842,9 @@ th a:focus i, th a:focus svg {
     fill: var(--bs-body-color) !important;
 }
 /* Docs */
+#post h2 {
+    margin-top: 2.5rem;
+}
 #post h3 {
     margin-top: 2rem;
 }


### PR DESCRIPTION
…ions

Canonical reference copies for the unified docs.html layout shared by docs and standards: a data-driven left sidebar nav, desktop/mobile "on this page" TOC blocks, and post-section partials (badges, links, scangov alert, image, audio, related). Also adds #post h2 spacing to scangov.css.