### PR TITLE
Add pattern library reference templates

### DIFF
--- a/public/templates/badges.html
+++ b/public/templates/badges.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Badges – ScanGov components</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+  <link rel="stylesheet" href="../css/scangov.css">
+</head>
+<body>
+
+<nav class="navbar navbar-expand-md border-bottom">
+  <div class="container-fluid">
+    <a class="navbar-brand small" href="index.html">
+      <i class="fa-solid fa-bars-progress me-1" aria-hidden="true"></i>
+      ScanGov
+    </a>
+  </div>
+</nav>
+
+<main id="main-content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12 col-md-10 col-lg-8 py-3">
+
+        <h1 class="display-6">Badges</h1>
+        <p class="text-body-secondary">
+          Grade and score badges use <code>class="badge text-bg-{color}"</code>.
+          <code>scangov.css</code> overrides Bootstrap's success/warning/danger colors
+          with WCAG 2.2 AA-verified values — don't hard-code the hex values in markup, just use the class.
+        </p>
+
+        <!-- Grade/score badges -->
+        <h2 class="h4 mt-5">Grade badges</h2>
+        <p class="small text-body-secondary">
+          Scores 0–100 map onto letter grades (A–F) and badge colors via two separate
+          scales. The color scale is coarser than the grade scale: only 3 colors regardless
+          of the 5-letter range. Use this mapping consistently across all sites.
+        </p>
+        <table class="table table-sm small mb-3">
+          <caption class="visually-hidden">Score-to-grade-to-color mapping</caption>
+          <thead>
+            <tr>
+              <th scope="col">Score</th>
+              <th scope="col">Grade</th>
+              <th scope="col">Badge color</th>
+              <th scope="col">Example</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>90–100</td>
+              <td>A</td>
+              <td><code>text-bg-success</code></td>
+              <td><span class="badge text-bg-success">A</span></td>
+            </tr>
+            <tr>
+              <td>80–89</td>
+              <td>B</td>
+              <td><code>text-bg-warning</code></td>
+              <td><span class="badge text-bg-warning">B</span></td>
+            </tr>
+            <tr>
+              <td>70–79</td>
+              <td>C</td>
+              <td><code>text-bg-warning</code></td>
+              <td><span class="badge text-bg-warning">C</span></td>
+            </tr>
+            <tr>
+              <td>60–69</td>
+              <td>D</td>
+              <td><code>text-bg-danger</code></td>
+              <td><span class="badge text-bg-danger">D</span></td>
+            </tr>
+            <tr>
+              <td>0–59</td>
+              <td>F</td>
+              <td><code>text-bg-danger</code></td>
+              <td><span class="badge text-bg-danger">F</span></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <!-- Status badges -->
+        <h2 class="h4 mt-5">Status badges</h2>
+        <p class="small text-body-secondary">
+          Use the same color tokens for non-grade status indicators (pass/fail, active/inactive, etc.).
+          The same WCAG-verified colors apply.
+        </p>
+        <div class="d-flex gap-2 flex-wrap mb-3">
+          <span class="badge text-bg-success">Pass</span>
+          <span class="badge text-bg-warning">Partial</span>
+          <span class="badge text-bg-danger">Fail</span>
+          <span class="badge text-bg-primary">Active</span>
+          <span class="badge text-bg-secondary">Inactive</span>
+        </div>
+
+        <!-- Markup -->
+        <h2 class="h4 mt-5">Markup</h2>
+        <pre class="border rounded p-3 small"><code>&lt;span class="badge text-bg-success"&gt;A&lt;/span&gt;
+&lt;span class="badge text-bg-warning"&gt;C&lt;/span&gt;
+&lt;span class="badge text-bg-danger"&gt;F&lt;/span&gt;
+&lt;span class="badge text-bg-primary"&gt;Active&lt;/span&gt;</code></pre>
+
+        <!-- Status icons -->
+        <h2 class="h4 mt-5">Status icons</h2>
+        <p class="small text-body-secondary">
+          For inline pass/fail indicators within a table cell or text, use Font Awesome
+          circle icons with text color utilities instead of a badge — these are inline,
+          not block-level elements. Used in the rankings Status column and compliance tables.
+          <code>fa-circle-check text-success</code>,
+          <code>fa-circle-xmark text-danger</code>, and
+          <code>fa-circle-exclamation text-warning</code> (for inaccessible/unknown state).
+        </p>
+        <div class="d-flex gap-3 align-items-center mb-3">
+          <span>
+            <i class="fa-solid fa-circle-check text-success" aria-hidden="true"></i>
+            <span class="small ms-1">Pass</span>
+          </span>
+          <span>
+            <i class="fa-solid fa-circle-xmark text-danger" aria-hidden="true"></i>
+            <span class="small ms-1">Fail</span>
+          </span>
+          <span>
+            <i class="fa-solid fa-circle-exclamation text-warning" aria-hidden="true"></i>
+            <span class="small ms-1">Unknown</span>
+          </span>
+        </div>
+        <pre class="border rounded p-3 small mb-5"><code>&lt;i class="fa-solid fa-circle-check text-success" aria-hidden="true"&gt;&lt;/i&gt;
+&lt;i class="fa-solid fa-circle-xmark text-danger" aria-hidden="true"&gt;&lt;/i&gt;
+&lt;i class="fa-solid fa-circle-exclamation text-warning" aria-hidden="true"&gt;&lt;/i&gt;</code></pre>
+
+        <!-- WCAG color reference -->
+        <h2 class="h4 mt-5">Color reference</h2>
+        <p class="small text-body-secondary">
+          These are the actual hex values <code>scangov.css</code> injects for the three status colors.
+          All pass WCAG 2.2 AA contrast (ratios in comments in the CSS).
+        </p>
+        <table class="table table-sm small">
+          <caption class="visually-hidden">Hex values for status badge colors</caption>
+          <thead>
+            <tr>
+              <th scope="col">Class</th>
+              <th scope="col">Background</th>
+              <th scope="col">Text</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>text-bg-success</code></td>
+              <td><code>#70e17b</code></td>
+              <td><code>#13171f</code></td>
+            </tr>
+            <tr>
+              <td><code>text-bg-warning</code></td>
+              <td><code>#face00</code></td>
+              <td><code>#000000</code></td>
+            </tr>
+            <tr>
+              <td><code>text-bg-danger</code></td>
+              <td><code>#e41d3d</code></td>
+              <td><code>#ffffff</code></td>
+            </tr>
+          </tbody>
+        </table>
+
+      </div>
+    </div>
+  </div>
+</main>
+
+</body>
+</html>

--- a/public/templates/breadcrumbs.html
+++ b/public/templates/breadcrumbs.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Breadcrumbs – ScanGov components</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+  <link rel="stylesheet" href="../css/scangov.css">
+</head>
+<body>
+
+<nav class="navbar navbar-expand-md border-bottom">
+  <div class="container-fluid">
+    <a class="navbar-brand small" href="index.html">
+      <i class="fa-solid fa-bars-progress me-1" aria-hidden="true"></i>
+      ScanGov
+    </a>
+  </div>
+</nav>
+
+<main id="main-content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12 col-md-10 col-lg-8 py-3">
+
+        <h1 class="display-6">Breadcrumbs</h1>
+        <p class="text-body-secondary">
+          Two distinct breadcrumb patterns are in use across ScanGov sites — choose based on
+          context, not preference. Both live in <code>components/_includes/</code>.
+        </p>
+
+        <!-- Default breadcrumb -->
+        <h2 class="h4 mt-5">Default breadcrumb</h2>
+        <p class="small text-body-secondary">
+          Use for standard page-level navigation (docs, standards, features, any non-profile page).
+          Uses Bootstrap's standard <code>.breadcrumb</code> with <code>.breadcrumb-default</code>
+          and <code>.font-monospace</code> styling. Source: <code>_includes/breadcrumb-default.html</code>.
+        </p>
+        <nav aria-label="Breadcrumb" class="breadcrumb-default mb-3">
+          <ol class="breadcrumb small font-monospace">
+            <li class="breadcrumb-item"><a href="#">Features</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Sites dashboard</li>
+          </ol>
+        </nav>
+        <pre class="border rounded p-3 small"><code>&lt;nav aria-label="Breadcrumb" class="breadcrumb-default mb-3"&gt;
+  &lt;ol class="breadcrumb small font-monospace"&gt;
+    &lt;li class="breadcrumb-item"&gt;&lt;a href="/parent/"&gt;Parent&lt;/a&gt;&lt;/li&gt;
+    &lt;li class="breadcrumb-item active" aria-current="page"&gt;Current page&lt;/li&gt;
+  &lt;/ol&gt;
+&lt;/nav&gt;</code></pre>
+
+        <!-- Profile breadcrumb -->
+        <h2 class="h4 mt-5">Profile breadcrumb</h2>
+        <p class="small text-body-secondary">
+          Use for the org&nbsp;&rarr;&nbsp;domain hierarchy in the site-monitoring context.
+          Custom classes <code>.bc-org</code>, <code>.bc-domain</code>, and <code>.bc-sep</code>
+          give the separator and each link type distinct theme-aware colors (defined in
+          <code>scangov.css</code>, lines ~535–590). A single <code>&lt;li&gt;</code> holds
+          the full path — don't nest multiple <code>&lt;li&gt;</code> elements.
+          Source: <code>_includes/breadcrumb-profile.html</code>.
+        </p>
+
+        <nav aria-label="breadcrumb" class="fs-5 font-monospace mb-3">
+          <ol class="breadcrumb mb-0">
+            <li class="breadcrumb-item">
+              <i class="fa-solid fa-hand-point-right" aria-hidden="true"></i>
+              <a href="#" class="bc-org">State of Iowa</a><span class="bc-sep"> / </span><a href="#" class="bc-domain">iowa.gov</a>
+            </li>
+          </ol>
+        </nav>
+        <pre class="border rounded p-3 small"><code>&lt;nav aria-label="breadcrumb" class="fs-5 font-monospace"&gt;
+  &lt;ol class="breadcrumb mb-0"&gt;
+    &lt;li class="breadcrumb-item"&gt;
+      &lt;i class="fa-solid fa-hand-point-right" aria-hidden="true"&gt;&lt;/i&gt;
+      &lt;a href="/org/org-name/" class="bc-org"&gt;Org Name&lt;/a&gt;
+      &lt;span class="bc-sep"&gt; / &lt;/span&gt;
+      &lt;a href="/profile/domain-gov/overall/" class="bc-domain"&gt;domain.gov&lt;/a&gt;
+    &lt;/li&gt;
+  &lt;/ol&gt;
+&lt;/nav&gt;</code></pre>
+
+        <!-- Org-only variant -->
+        <h2 class="h4 mt-5">Profile breadcrumb — org current</h2>
+        <p class="small text-body-secondary">
+          When the org itself is the current page (not a specific domain), use
+          <code>.bc-org-current</code> on the org link instead of <code>.bc-org</code>
+          and omit the separator and domain link.
+        </p>
+        <nav aria-label="breadcrumb" class="fs-5 font-monospace mb-3">
+          <ol class="breadcrumb mb-0">
+            <li class="breadcrumb-item" aria-current="page">
+              <i class="fa-solid fa-hand-point-right" aria-hidden="true"></i>
+              <a href="#" class="bc-org-current">State of Iowa</a>
+            </li>
+          </ol>
+        </nav>
+        <pre class="border rounded p-3 small"><code>&lt;li class="breadcrumb-item" aria-current="page"&gt;
+  &lt;i class="fa-solid fa-hand-point-right" aria-hidden="true"&gt;&lt;/i&gt;
+  &lt;a href="/org/org-name/" class="bc-org-current"&gt;Org Name&lt;/a&gt;
+&lt;/li&gt;</code></pre>
+
+      </div>
+    </div>
+  </div>
+</main>
+
+</body>
+</html>

--- a/public/templates/buttons.html
+++ b/public/templates/buttons.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Buttons – ScanGov components</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+  <link rel="stylesheet" href="../css/scangov.css">
+</head>
+<body>
+
+<nav class="navbar navbar-expand-md border-bottom">
+  <div class="container-fluid">
+    <a class="navbar-brand small" href="index.html">
+      <i class="fa-solid fa-bars-progress me-1" aria-hidden="true"></i>
+      ScanGov
+    </a>
+  </div>
+</nav>
+
+<main id="main-content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12 col-md-10 col-lg-8 py-3">
+
+        <h1 class="display-6">Buttons</h1>
+        <p class="text-body-secondary">
+          Two button patterns in regular use: primary and outline. Both get custom
+          scangov styling on top of Bootstrap. Be careful with <code>btn-outline-primary</code>
+          (Bootstrap class, customized) vs <code>btn-primary-outline</code>
+          (scangov-only, for nav-pills — documented separately below).
+        </p>
+
+        <!-- Primary -->
+        <h2 class="h4 mt-5">Primary</h2>
+        <p class="small text-body-secondary">
+          Standard call-to-action button. Uses <code>var(--bs-primary)</code> for background
+          and border, so it inherits the site's brand color. Add an icon with
+          <code>me-2</code> margin before the label.
+        </p>
+        <div class="d-flex gap-2 flex-wrap align-items-center mb-3">
+          <a href="#" class="btn btn-primary btn-lg"><i class="fa-solid fa-rocket me-2" aria-hidden="true"></i>Get started</a>
+          <a href="#" class="btn btn-primary"><i class="fa-solid fa-calendar-check me-2" aria-hidden="true"></i>Schedule demo</a>
+          <a href="#" class="btn btn-primary btn-sm">Learn more</a>
+        </div>
+        <pre class="border rounded p-3 small mb-5"><code>&lt;a href="..." class="btn btn-primary btn-lg"&gt;
+  &lt;i class="fa-solid fa-rocket me-2" aria-hidden="true"&gt;&lt;/i&gt;Get started
+&lt;/a&gt;
+&lt;a href="..." class="btn btn-primary"&gt;Default&lt;/a&gt;
+&lt;a href="..." class="btn btn-primary btn-sm"&gt;Small&lt;/a&gt;</code></pre>
+
+        <!-- Outline -->
+        <h2 class="h4 mt-5">Outline</h2>
+        <p class="small text-body-secondary">
+          Use for secondary actions. <strong>Non-obvious behavior:</strong>
+          <code>scangov.css</code> adds <code>margin-top: 1rem</code> to
+          <code>.btn.btn-outline-primary</code> automatically <em>unless</em>
+          <code>.btn-lg</code> is also present. This is intentional spacing for inline
+          use alongside body text — but wrap in a flex/grid container with
+          <code>align-items-center</code> or override with <code>mt-0</code> if the
+          automatic margin causes layout issues.
+        </p>
+        <div class="mb-3">
+          <a href="#" class="btn btn-outline-primary btn-lg">Large outline (no auto-margin)</a>
+        </div>
+        <div class="mb-3">
+          <a href="#" class="btn btn-outline-primary">Default outline (gets margin-top: 1rem)</a>
+        </div>
+        <div class="mb-3">
+          <a href="#" class="btn btn-outline-primary btn-sm">Small outline (gets margin-top: 1rem)</a>
+        </div>
+        <pre class="border rounded p-3 small mb-5"><code>&lt;a href="..." class="btn btn-outline-primary btn-lg"&gt;Large outline&lt;/a&gt;
+&lt;a href="..." class="btn btn-outline-primary"&gt;Default outline&lt;/a&gt;
+&lt;a href="..." class="btn btn-outline-primary btn-sm"&gt;Small outline&lt;/a&gt;</code></pre>
+
+        <!-- btn-primary-outline (nav-pills only) -->
+        <h2 class="h4 mt-5"><code>btn-primary-outline</code> — nav-pills only</h2>
+        <p class="small text-body-secondary">
+          <code>a.btn-primary-outline</code> is <strong>not</strong> a general button variant.
+          Despite the similar name, it's a different class from Bootstrap's
+          <code>btn-outline-primary</code>. It's styled specifically for
+          <code>.nav-pills a.btn-primary-outline</code> — the active/hover/focus rules
+          in <code>scangov.css</code> are all scoped to <code>.nav-pills</code>.
+          Using it outside a nav-pills context will produce unstyled or inconsistent output.
+          See <a href="nav-tabs.html">nav-tabs.html</a> for correct usage in context.
+        </p>
+        <ul class="nav nav-pills mb-3">
+          <li class="nav-item">
+            <a class="btn-primary-outline nav-link active" aria-current="page" href="#">Active pill</a>
+          </li>
+          <li class="nav-item">
+            <a class="btn-primary-outline nav-link" href="#">Inactive pill</a>
+          </li>
+          <li class="nav-item">
+            <a class="btn-primary-outline nav-link" href="#">Another pill</a>
+          </li>
+        </ul>
+
+      </div>
+    </div>
+  </div>
+</main>
+
+</body>
+</html>

--- a/public/templates/cards.html
+++ b/public/templates/cards.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Cards – ScanGov components</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+  <link rel="stylesheet" href="../css/scangov.css">
+</head>
+<body>
+
+<nav class="navbar navbar-expand-md border-bottom">
+  <div class="container-fluid">
+    <a class="navbar-brand small" href="index.html">
+      <i class="fa-solid fa-bars-progress me-1" aria-hidden="true"></i>
+      ScanGov
+    </a>
+  </div>
+</nav>
+
+<main id="main-content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12 col-md-10 col-lg-8 py-3">
+
+        <h1 class="display-6">Cards</h1>
+        <p class="text-body-secondary">
+          <code>scangov.css</code> adds border, shadow, hover-brightness, and focus-ring
+          to every <code>.card</code> automatically — don't add these manually.
+          Status-variant cards and link cards (stretched-link) have additional automatic behavior
+          documented below.
+        </p>
+
+        <!-- Standard card -->
+        <h2 class="h4 mt-5">Standard</h2>
+        <p class="small text-body-secondary">
+          A plain <code>.card</code> gets border, shadow, and a brightness hover effect automatically.
+          No extra classes needed for that base styling.
+        </p>
+        <div class="row g-3 mb-4">
+          <div class="col-12 col-md-4">
+            <div class="card">
+              <div class="card-body">
+                <h3 class="h5">Card title</h3>
+                <p class="card-text small text-body-secondary">Supporting detail or description goes here.</p>
+              </div>
+            </div>
+          </div>
+          <div class="col-12 col-md-4">
+            <div class="card">
+              <div class="card-body">
+                <i class="fa-solid fa-gauge-high fa-lg d-block mb-2" aria-hidden="true"></i>
+                <h3 class="h5 mt-3">Card with icon</h3>
+                <p class="card-text small text-body-secondary">Icon sits above the heading inside card-body.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Stretched-link card grid -->
+        <h2 class="h4 mt-5">Link cards (stretched-link)</h2>
+        <p class="small text-body-secondary">
+          Adding a <code>.stretched-link</code> anchor inside a card triggers an automatic
+          blue-tinted border and a distinct hover effect via the <code>:has()</code> selector
+          in <code>scangov.css</code> — no extra class needed. The entire card becomes the
+          click target.
+        </p>
+        <div class="row g-3 mb-4">
+          <div class="col-12 col-md-4 d-flex align-items-stretch">
+            <div class="card">
+              <div class="card-body">
+                <i class="fa-solid fa-universal-access fa-lg d-block mb-2" aria-hidden="true"></i>
+                <h3 class="h5 mt-3"><a href="#" class="stretched-link">Accessibility</a></h3>
+                <p class="card-text small text-body-secondary">Multi-site management.</p>
+              </div>
+            </div>
+          </div>
+          <div class="col-12 col-md-4 d-flex align-items-stretch">
+            <div class="card">
+              <div class="card-body">
+                <i class="fa-solid fa-shield-halved fa-lg d-block mb-2" aria-hidden="true"></i>
+                <h3 class="h5 mt-3"><a href="#" class="stretched-link">Security</a></h3>
+                <p class="card-text small text-body-secondary">Status by indicator.</p>
+              </div>
+            </div>
+          </div>
+          <div class="col-12 col-md-4 d-flex align-items-stretch">
+            <div class="card">
+              <div class="card-body">
+                <i class="fa-solid fa-robot fa-lg d-block mb-2" aria-hidden="true"></i>
+                <h3 class="h5 mt-3"><a href="#" class="stretched-link">Botability</a></h3>
+                <p class="card-text small text-body-secondary">Top-level overview.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Status variant cards -->
+        <h2 class="h4 mt-5">Status cards</h2>
+        <p class="small text-body-secondary">
+          Add <code>text-bg-success</code>, <code>text-bg-warning</code>, or <code>text-bg-danger</code>
+          to a <code>.card</code> to apply the WCAG-verified status colors (same as badge colors).
+          The <code>.card-header</code> automatically gets a semi-transparent white overlay.
+          Icons and links inside status cards inherit the card's text color automatically.
+          These cards do NOT get the standard hover-brightness effect — they have their own hover treatment.
+        </p>
+        <div class="row g-3 mb-4">
+          <div class="col-12 col-md-4">
+            <div class="card text-bg-success">
+              <div class="card-header">iowa.gov</div>
+              <div class="card-body text-center">
+                <div class="display-4">A</div>
+                <div class="small">95 / 100</div>
+              </div>
+            </div>
+          </div>
+          <div class="col-12 col-md-4">
+            <div class="card text-bg-warning">
+              <div class="card-header">hiv.gov</div>
+              <div class="card-body text-center">
+                <div class="display-4">C</div>
+                <div class="small">72 / 100</div>
+              </div>
+            </div>
+          </div>
+          <div class="col-12 col-md-4">
+            <div class="card text-bg-danger">
+              <div class="card-header">example.gov</div>
+              <div class="card-body text-center">
+                <div class="display-4">F</div>
+                <div class="small">42 / 100</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Markup -->
+        <h2 class="h4 mt-5">Markup</h2>
+        <pre class="border rounded p-3 small"><code>&lt;!-- Standard --&gt;
+&lt;div class="card"&gt;
+  &lt;div class="card-body"&gt;...&lt;/div&gt;
+&lt;/div&gt;
+
+&lt;!-- Link card (stretched-link) --&gt;
+&lt;div class="card"&gt;
+  &lt;div class="card-body"&gt;
+    &lt;h3&gt;&lt;a href="/..." class="stretched-link"&gt;Title&lt;/a&gt;&lt;/h3&gt;
+    &lt;p class="card-text small"&gt;Description&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+
+&lt;!-- Status card --&gt;
+&lt;div class="card text-bg-success"&gt;
+  &lt;div class="card-header"&gt;domain.gov&lt;/div&gt;
+  &lt;div class="card-body text-center"&gt;
+    &lt;div class="display-4"&gt;A&lt;/div&gt;
+    &lt;div class="small"&gt;95 / 100&lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+
+      </div>
+    </div>
+  </div>
+</main>
+
+</body>
+</html>

--- a/public/templates/forms.html
+++ b/public/templates/forms.html
@@ -1,0 +1,160 @@
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Forms – ScanGov components</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+  <link rel="stylesheet" href="../css/scangov.css">
+</head>
+<body>
+
+<nav class="navbar navbar-expand-md border-bottom">
+  <div class="container-fluid">
+    <a class="navbar-brand small" href="index.html">
+      <i class="fa-solid fa-bars-progress me-1" aria-hidden="true"></i>
+      ScanGov
+    </a>
+  </div>
+</nav>
+
+<main id="main-content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12 col-md-10 col-lg-8 py-3">
+
+        <h1 class="display-6">Forms</h1>
+        <p class="text-body-secondary">
+          Standard Bootstrap 5 form classes apply throughout. <code>scangov.css</code> adds
+          minor hover/focus enhancements to <code>.form-control</code> — no extra classes needed
+          for that. Always pair inputs with <code>&lt;label&gt;</code> elements using matching
+          <code>for</code>/<code>id</code> attributes.
+        </p>
+
+        <!-- Text inputs -->
+        <h2 class="h4 mt-5">Text inputs</h2>
+        <p class="small text-body-secondary">
+          Use <code>.form-control</code> for text, email, password, and textarea inputs.
+          Wrap each input and label in <code>.mb-3</code> for consistent spacing.
+        </p>
+        <form class="mb-4" novalidate>
+          <div class="mb-3">
+            <label for="input-email" class="form-label">Email address</label>
+            <input type="email" class="form-control" id="input-email" placeholder="name@agency.gov">
+          </div>
+          <div class="mb-3">
+            <label for="input-password" class="form-label">Password</label>
+            <input type="password" class="form-control" id="input-password">
+          </div>
+          <div class="mb-3">
+            <label for="input-textarea" class="form-label">Notes</label>
+            <textarea class="form-control" id="input-textarea" rows="3"></textarea>
+          </div>
+        </form>
+        <pre class="border rounded p-3 small mb-5"><code>&lt;div class="mb-3"&gt;
+  &lt;label for="input-email" class="form-label"&gt;Email address&lt;/label&gt;
+  &lt;input type="email" class="form-control" id="input-email"&gt;
+&lt;/div&gt;</code></pre>
+
+        <!-- Search -->
+        <h2 class="h4 mt-5">Search</h2>
+        <p class="small text-body-secondary">
+          Add <code>shadow</code> to the search input — this is the established pattern
+          across ScanGov sites. Use with a <code>&lt;datalist&gt;</code> for autocomplete
+          or connect to a search handler via JS.
+        </p>
+        <div class="mb-3 col-12 col-md-6">
+          <label for="input-search" class="form-label visually-hidden">Search</label>
+          <input type="search" class="form-control shadow" id="input-search" placeholder="Search sites…" aria-label="Search">
+        </div>
+        <pre class="border rounded p-3 small mb-5"><code>&lt;input type="search" class="form-control shadow" id="search"
+  placeholder="Search…" aria-label="Search"&gt;</code></pre>
+
+        <!-- Select -->
+        <h2 class="h4 mt-5">Select</h2>
+        <p class="small text-body-secondary">
+          Use <code>.form-select</code> for dropdowns.
+        </p>
+        <div class="mb-3 col-12 col-md-6">
+          <label for="input-select" class="form-label">Indicator</label>
+          <select class="form-select" id="input-select">
+            <option selected>All indicators</option>
+            <option>Accessibility</option>
+            <option>Botability</option>
+            <option>Security</option>
+            <option>Usability</option>
+          </select>
+        </div>
+        <pre class="border rounded p-3 small mb-5"><code>&lt;label for="input-select" class="form-label"&gt;Indicator&lt;/label&gt;
+&lt;select class="form-select" id="input-select"&gt;
+  &lt;option selected&gt;All indicators&lt;/option&gt;
+  &lt;option&gt;Accessibility&lt;/option&gt;
+&lt;/select&gt;</code></pre>
+
+        <!-- Checkboxes -->
+        <h2 class="h4 mt-5">Checkboxes</h2>
+        <p class="small text-body-secondary">
+          Use <code>.form-check</code> wrappers with <code>.form-check-input</code> and
+          <code>.form-check-label</code>. Each checkbox needs its own unique <code>id</code>.
+        </p>
+        <div class="mb-4">
+          <div class="form-check mb-2">
+            <input class="form-check-input" type="checkbox" id="check-1" checked>
+            <label class="form-check-label" for="check-1">iowa.gov</label>
+          </div>
+          <div class="form-check mb-2">
+            <input class="form-check-input" type="checkbox" id="check-2">
+            <label class="form-check-label" for="check-2">hiv.gov</label>
+          </div>
+          <div class="form-check mb-2">
+            <input class="form-check-input" type="checkbox" id="check-3" disabled>
+            <label class="form-check-label" for="check-3">example.gov (disabled)</label>
+          </div>
+        </div>
+        <pre class="border rounded p-3 small mb-5"><code>&lt;div class="form-check mb-2"&gt;
+  &lt;input class="form-check-input" type="checkbox" id="check-1"&gt;
+  &lt;label class="form-check-label" for="check-1"&gt;Label&lt;/label&gt;
+&lt;/div&gt;</code></pre>
+
+        <!-- File upload -->
+        <h2 class="h4 mt-5">File upload</h2>
+        <div class="mb-3 col-12 col-md-6">
+          <label for="input-file" class="form-label">Upload domain list</label>
+          <input class="form-control" type="file" id="input-file" accept=".csv,.txt">
+        </div>
+        <pre class="border rounded p-3 small mb-5"><code>&lt;label for="input-file" class="form-label"&gt;Upload domain list&lt;/label&gt;
+&lt;input class="form-control" type="file" id="input-file" accept=".csv,.txt"&gt;</code></pre>
+
+        <!-- Validation states -->
+        <h2 class="h4 mt-5">Validation states</h2>
+        <p class="small text-body-secondary">
+          Use Bootstrap's <code>.is-valid</code> / <code>.is-invalid</code> on the input
+          and a sibling <code>.valid-feedback</code> / <code>.invalid-feedback</code> element.
+          Add <code>novalidate</code> on the form to manage validation via JS.
+        </p>
+        <form class="mb-4" novalidate>
+          <div class="mb-3">
+            <label for="input-valid" class="form-label">Domain (valid)</label>
+            <input type="text" class="form-control is-valid" id="input-valid" value="iowa.gov">
+            <div class="valid-feedback">Looks good.</div>
+          </div>
+          <div class="mb-3">
+            <label for="input-invalid" class="form-label">Domain (invalid)</label>
+            <input type="text" class="form-control is-invalid" id="input-invalid" value="not a domain">
+            <div class="invalid-feedback">Enter a valid domain, e.g. <code>agency.gov</code>.</div>
+          </div>
+        </form>
+        <pre class="border rounded p-3 small"><code>&lt;input type="text" class="form-control is-valid" id="..."&gt;
+&lt;div class="valid-feedback"&gt;Looks good.&lt;/div&gt;
+
+&lt;input type="text" class="form-control is-invalid" id="..."&gt;
+&lt;div class="invalid-feedback"&gt;Error message.&lt;/div&gt;</code></pre>
+
+      </div>
+    </div>
+  </div>
+</main>
+
+</body>
+</html>

--- a/public/templates/index.html
+++ b/public/templates/index.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ScanGov component patterns</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+  <link rel="stylesheet" href="../css/scangov.css">
+</head>
+<body>
+
+<nav class="navbar navbar-expand-md border-bottom">
+  <div class="container-fluid">
+    <a class="navbar-brand small" href="#">
+      <i class="fa-solid fa-bars-progress me-1" aria-hidden="true"></i>
+      ScanGov
+    </a>
+  </div>
+</nav>
+
+<main id="main-content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12 col-md-10 col-lg-8 py-3">
+
+        <h1 class="display-6">Component patterns</h1>
+        <p class="text-body-secondary">
+          Live reference pages for UI conventions used across ScanGov sites.
+          All examples use <code>scangov.css</code> + Bootstrap 5 (dark theme default).
+          These are the canonical patterns to copy from for new builds and cleanup of existing sites.
+        </p>
+
+        <div class="row g-3 mt-2">
+
+          <div class="col-12 col-md-6">
+            <div class="card">
+              <div class="card-body">
+                <h2 class="h5"><a href="badges.html" class="stretched-link">Badges</a></h2>
+                <p class="card-text small text-body-secondary">Grade/score badge color mapping (A–F, 3 WCAG-verified status colors), markup, and hex reference.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-12 col-md-6">
+            <div class="card">
+              <div class="card-body">
+                <h2 class="h5"><a href="breadcrumbs.html" class="stretched-link">Breadcrumbs</a></h2>
+                <p class="card-text small text-body-secondary">Default Bootstrap breadcrumb vs. profile-style org&thinsp;/&thinsp;domain hierarchy — when to use which.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-12 col-md-6">
+            <div class="card">
+              <div class="card-body">
+                <h2 class="h5"><a href="buttons.html" class="stretched-link">Buttons</a></h2>
+                <p class="card-text small text-body-secondary">Primary and outline buttons, sizes, the automatic outline margin-top behavior, and the nav-pills-only <code>btn-primary-outline</code>.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-12 col-md-6">
+            <div class="card">
+              <div class="card-body">
+                <h2 class="h5"><a href="cards.html" class="stretched-link">Cards</a></h2>
+                <p class="card-text small text-body-secondary">Standard, stretched-link, and status-variant cards (success/warning/danger) with automatic WCAG colors.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-12 col-md-6">
+            <div class="card">
+              <div class="card-body">
+                <h2 class="h5"><a href="nav-tabs.html" class="stretched-link">Nav tabs &amp; pills</a></h2>
+                <p class="card-text small text-body-secondary">Top-level site nav (<code>topnav</code>), topic filter tabs (<code>filter</code>), and segmented pill controls — plus icon color behavior.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-12 col-md-6">
+            <div class="card">
+              <div class="card-body">
+                <h2 class="h5"><a href="tables.html" class="stretched-link">Tables</a></h2>
+                <p class="card-text small text-body-secondary">Standard, sortable, and dense data tables — <code>table-responsive</code> wrapper, bare <code>.table</code> class, and caption requirements.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-12 col-md-6">
+            <div class="card">
+              <div class="card-body">
+                <h2 class="h5"><a href="forms.html" class="stretched-link">Forms</a></h2>
+                <p class="card-text small text-body-secondary">Text inputs, search, selects, checkboxes, file upload, and validation states.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-12 col-md-6">
+            <div class="card">
+              <div class="card-body">
+                <h2 class="h5"><a href="sidebar.html" class="stretched-link">Sidebar</a></h2>
+                <p class="card-text small text-body-secondary">Sticky vertical list-group sidebar in a two-column layout, and horizontal list-group for action/share groups.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-12 col-md-6">
+            <div class="card">
+              <div class="card-body">
+                <h2 class="h5"><a href="timeline.html" class="stretched-link">Timeline</a></h2>
+                <p class="card-text small text-body-secondary">Custom scangov.css component for step-by-step process flows and changelog entries.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-12 col-md-6">
+            <div class="card">
+              <div class="card-body">
+                <h2 class="h5"><a href="toasts.html" class="stretched-link">Toasts &amp; loading</a></h2>
+                <p class="card-text small text-body-secondary">Spinner, icon spin for button pending states, and Bootstrap toast notifications with proper ARIA.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-12 col-md-6">
+            <div class="card">
+              <div class="card-body">
+                <h2 class="h5"><a href="scans.html" class="stretched-link">Scans page</a></h2>
+                <p class="card-text small text-body-secondary">Full page mockup: sidebar nav, scan-history table, progress bars, breadcrumb profile style, and alert banner.</p>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+      </div>
+    </div>
+  </div>
+</main>
+
+</body>
+</html>

--- a/public/templates/nav-tabs.html
+++ b/public/templates/nav-tabs.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Nav tabs &amp; pills – ScanGov components</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+  <link rel="stylesheet" href="../css/scangov.css">
+</head>
+<body>
+
+<nav class="navbar navbar-expand-md border-bottom">
+  <div class="container-fluid">
+    <a class="navbar-brand small" href="index.html">
+      <i class="fa-solid fa-bars-progress me-1" aria-hidden="true"></i>
+      ScanGov
+    </a>
+  </div>
+</nav>
+
+<main id="main-content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12 col-md-10 col-lg-8 py-3">
+
+        <h1 class="display-6">Nav tabs &amp; pills</h1>
+        <p class="text-body-secondary">
+          Three distinct navigation patterns in use across ScanGov sites — each styled differently
+          via <code>scangov.css</code>. Choose by context. Icon colors inside nav-tabs and nav-pills
+          are set per icon via 100+ <code>.fa-*</code> rules in <code>scangov.css</code>
+          (dark and light mode variants) — they are inherited automatically; don't override them inline.
+        </p>
+
+        <!-- nav-tabs topnav -->
+        <h2 class="h4 mt-5">Top-level site nav (<code>nav-tabs topnav</code>)</h2>
+        <p class="small text-body-secondary">
+          Used for the cross-site navigation bar at the top of scangov.org and related sites.
+          Tabs have a bottom-open border, rounded top corners, and an active bright-primary fill.
+          Source: <code>_includes/nav.html</code>.
+        </p>
+        <ul class="nav nav-tabs topnav small mb-0">
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">
+              <i class="fa-solid fa-bars-progress" aria-hidden="true"></i> Rankings
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">
+              <i class="fa-solid fa-star" aria-hidden="true"></i> Standards
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">
+              <i class="fa-solid fa-scroll" aria-hidden="true"></i> Guidance
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">
+              <i class="fa-solid fa-database" aria-hidden="true"></i> Data
+            </a>
+          </li>
+        </ul>
+        <pre class="border rounded p-3 small mt-3 mb-5"><code>&lt;ul class="nav nav-tabs topnav small mb-0"&gt;
+  &lt;li class="nav-item"&gt;
+    &lt;a class="nav-link active" aria-current="page" href="..."&gt;
+      &lt;i class="fa-solid fa-bars-progress" aria-hidden="true"&gt;&lt;/i&gt; Label
+    &lt;/a&gt;
+  &lt;/li&gt;
+  &lt;li class="nav-item"&gt;
+    &lt;a class="nav-link" href="..."&gt;Label&lt;/a&gt;
+  &lt;/li&gt;
+&lt;/ul&gt;</code></pre>
+
+        <!-- nav-tabs filter -->
+        <h2 class="h4 mt-5">Topic filter tabs (<code>nav-tabs filter</code>)</h2>
+        <p class="small text-body-secondary">
+          Used for indicator/topic switching within a page (rankings, profile details, standards).
+          Rendered via the <code>_includes/filter-pill.html</code> partial — set
+          <code>pillTitle</code>, <code>pillUrl</code>, <code>pillIcon</code>, and
+          <code>pillActive</code> before including. Active tab gets a bright-primary fill.
+        </p>
+        <ul class="nav nav-tabs filter small mb-0">
+          <li class="nav-item">
+            <a class="nav-link active mx-1" aria-current="page" href="#">
+              <i class="fa-solid fa-circle-notch" aria-hidden="true"></i> All
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link mx-1" href="#">
+              <i class="fa-solid fa-universal-access" aria-hidden="true"></i> Accessibility
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link mx-1" href="#">
+              <i class="fa-solid fa-robot" aria-hidden="true"></i> Botability
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link mx-1" href="#">
+              <i class="fa-solid fa-shield-halved" aria-hidden="true"></i> Security
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link mx-1" href="#">
+              <i class="fa-solid fa-hand-pointer" aria-hidden="true"></i> Usability
+            </a>
+          </li>
+        </ul>
+        <pre class="border rounded p-3 small mt-3 mb-5"><code>&lt;ul class="nav nav-tabs filter small mb-0"&gt;
+  &lt;li class="nav-item"&gt;
+    &lt;a class="nav-link active mx-1" aria-current="page" href="..."&gt;
+      &lt;i class="fa-solid fa-circle-notch" aria-hidden="true"&gt;&lt;/i&gt; All
+    &lt;/a&gt;
+  &lt;/li&gt;
+  &lt;li class="nav-item"&gt;
+    &lt;a class="nav-link mx-1" href="..."&gt;
+      &lt;i class="fa-solid fa-{icon}" aria-hidden="true"&gt;&lt;/i&gt; Label
+    &lt;/a&gt;
+  &lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;!-- In Eleventy/Nunjucks, use the filter-pill.html include: --&gt;
+&lt;!-- {% set pillTitle = "Label" %}{% set pillUrl = "/path/" %} --&gt;
+&lt;!-- {% set pillIcon = "fa-solid fa-{icon}" %}{% set pillActive = true %} --&gt;
+&lt;!-- {% include "filter-pill.html" %} --&gt;</code></pre>
+
+        <!-- nav-pills filter (segmented) -->
+        <h2 class="h4 mt-5">Segmented control (<code>nav-pills filter</code>)</h2>
+        <p class="small text-body-secondary">
+          Use for compact multi-segment switches — e.g., All / Cities / States / Federal in
+          the rankings. Pill links without bottom-open borders; active state fills primary color.
+          No icon typically needed.
+        </p>
+        <ul class="nav nav-pills filter small mb-3">
+          <li class="nav-item">
+            <a class="nav-link active mx-1" aria-current="page" href="#">All</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link mx-1" href="#">Cities</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link mx-1" href="#">States</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link mx-1" href="#">Federal</a>
+          </li>
+        </ul>
+        <pre class="border rounded p-3 small mb-5"><code>&lt;ul class="nav nav-pills filter small mb-0"&gt;
+  &lt;li class="nav-item"&gt;
+    &lt;a class="nav-link active mx-1" aria-current="page" href="..."&gt;All&lt;/a&gt;
+  &lt;/li&gt;
+  &lt;li class="nav-item"&gt;
+    &lt;a class="nav-link mx-1" href="..."&gt;Cities&lt;/a&gt;
+  &lt;/li&gt;
+&lt;/ul&gt;</code></pre>
+
+        <!-- Icon colors note -->
+        <h2 class="h4 mt-5">Icon coloring</h2>
+        <p class="small text-body-secondary">
+          Icons inside nav-tabs and nav-pills receive automatic per-indicator colors
+          (e.g., accessibility icon is one color, security another) defined by 100+
+          <code>.fa-*</code> rules in <code>scangov.css</code>. Both dark and light
+          mode variants are included. Do not set icon colors inline — they are applied
+          automatically once the correct Font Awesome class is used.
+          See the <code>/* Per-icon colors */</code> sections in <code>scangov.css</code>
+          for the full list.
+        </p>
+
+      </div>
+    </div>
+  </div>
+</main>
+
+</body>
+</html>

--- a/public/templates/sidebar.html
+++ b/public/templates/sidebar.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sidebar – ScanGov components</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+  <link rel="stylesheet" href="../css/scangov.css">
+</head>
+<body>
+
+<nav class="navbar navbar-expand-md border-bottom">
+  <div class="container-fluid">
+    <a class="navbar-brand small" href="index.html">
+      <i class="fa-solid fa-bars-progress me-1" aria-hidden="true"></i>
+      ScanGov
+    </a>
+  </div>
+</nav>
+
+<main id="main-content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12 col-md-10 col-lg-8 py-3">
+
+        <h1 class="display-6">Sidebar</h1>
+        <p class="text-body-secondary">
+          Vertical sidebar navigation using Bootstrap's <code>.list-group</code> with
+          <code>.list-group-item-action</code> links. Use in a <code>col-md-2</code>
+          column alongside a <code>col-md-10</code> main content column, with
+          <code>position-sticky</code> to keep it in view while the content scrolls.
+        </p>
+
+        <!-- Sidebar in layout context -->
+        <h2 class="h4 mt-5">Sidebar with content area</h2>
+        <p class="small text-body-secondary">
+          The standard two-column layout: narrow sticky sidebar left, main content right.
+          The active item uses <code>.active</code> and <code>aria-current="page"</code>.
+          Each icon is followed by a <code>&lt;small&gt;</code> label.
+        </p>
+        <div class="row border rounded mb-4" style="min-height: 280px;">
+
+          <div class="col-12 col-sm-12 col-md-2 col-lg-2 border-end py-3">
+            <div class="list-group list-group-flush position-sticky" style="top: 1rem;">
+              <a href="#" class="list-group-item list-group-item-action">
+                <i class="fa-solid fa-gauge" aria-hidden="true"></i>
+                <small> Dashboard</small>
+              </a>
+              <a href="#" class="list-group-item list-group-item-action active" aria-current="page">
+                <i class="fa-solid fa-universal-access" aria-hidden="true"></i>
+                <small> Accessibility</small>
+              </a>
+              <a href="#" class="list-group-item list-group-item-action">
+                <i class="fa-solid fa-shield-halved" aria-hidden="true"></i>
+                <small> Security</small>
+              </a>
+              <a href="#" class="list-group-item list-group-item-action">
+                <i class="fa-solid fa-robot" aria-hidden="true"></i>
+                <small> Botability</small>
+              </a>
+              <a href="#" class="list-group-item list-group-item-action">
+                <i class="fa-solid fa-hand-pointer" aria-hidden="true"></i>
+                <small> Usability</small>
+              </a>
+              <a href="#" class="list-group-item list-group-item-action">
+                <i class="fa-solid fa-up-right-from-square" aria-hidden="true"></i>
+                <small> Visit site</small>
+              </a>
+            </div>
+          </div>
+
+          <div class="col-12 col-sm-12 col-md-10 col-lg-10 py-3">
+            <p class="text-body-secondary small">Main content area</p>
+          </div>
+
+        </div>
+        <pre class="border rounded p-3 small mb-5"><code>&lt;div class="row"&gt;
+  &lt;div class="col-12 col-md-2"&gt;
+    &lt;div class="list-group list-group-flush position-sticky" style="top: 1rem;"&gt;
+      &lt;a href="..." class="list-group-item list-group-item-action"&gt;
+        &lt;i class="fa-solid fa-gauge" aria-hidden="true"&gt;&lt;/i&gt;
+        &lt;small&gt; Dashboard&lt;/small&gt;
+      &lt;/a&gt;
+      &lt;a href="..." class="list-group-item list-group-item-action active" aria-current="page"&gt;
+        &lt;i class="fa-solid fa-universal-access" aria-hidden="true"&gt;&lt;/i&gt;
+        &lt;small&gt; Accessibility&lt;/small&gt;
+      &lt;/a&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+  &lt;div class="col-12 col-md-10"&gt;
+    &lt;!-- main content --&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+
+        <!-- Horizontal list-group -->
+        <h2 class="h4 mt-5">Horizontal list-group</h2>
+        <p class="small text-body-secondary">
+          Use <code>.list-group-horizontal-sm</code> for inline action or share button groups.
+          Stacks vertically on xs, horizontal from sm and up.
+        </p>
+        <ul class="list-group list-group-horizontal-sm mb-4">
+          <li class="list-group-item list-group-item-action">
+            <i class="fa-brands fa-linkedin" aria-hidden="true"></i><small> LinkedIn</small>
+          </li>
+          <li class="list-group-item list-group-item-action">
+            <i class="fa-brands fa-bluesky" aria-hidden="true"></i><small> Bluesky</small>
+          </li>
+          <li class="list-group-item list-group-item-action">
+            <i class="fa-regular fa-clipboard" aria-hidden="true"></i><small> Copy link</small>
+          </li>
+        </ul>
+        <pre class="border rounded p-3 small"><code>&lt;ul class="list-group list-group-horizontal-sm"&gt;
+  &lt;li class="list-group-item list-group-item-action"&gt;
+    &lt;i class="fa-brands fa-linkedin" aria-hidden="true"&gt;&lt;/i&gt;&lt;small&gt; LinkedIn&lt;/small&gt;
+  &lt;/li&gt;
+  &lt;li class="list-group-item list-group-item-action"&gt;
+    &lt;i class="fa-regular fa-clipboard" aria-hidden="true"&gt;&lt;/i&gt;&lt;small&gt; Copy link&lt;/small&gt;
+  &lt;/li&gt;
+&lt;/ul&gt;</code></pre>
+
+      </div>
+    </div>
+  </div>
+</main>
+
+</body>
+</html>

--- a/public/templates/timeline.html
+++ b/public/templates/timeline.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Timeline – ScanGov components</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+  <link rel="stylesheet" href="../css/scangov.css">
+</head>
+<body>
+
+<nav class="navbar navbar-expand-md border-bottom">
+  <div class="container-fluid">
+    <a class="navbar-brand small" href="index.html">
+      <i class="fa-solid fa-bars-progress me-1" aria-hidden="true"></i>
+      ScanGov
+    </a>
+  </div>
+</nav>
+
+<main id="main-content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12 col-md-10 col-lg-8 py-3">
+
+        <h1 class="display-6">Timeline</h1>
+        <p class="text-body-secondary">
+          A custom <code>scangov.css</code> component — not part of Bootstrap.
+          Uses a left-border line with dot markers (<code>:after</code> pseudo-element)
+          to connect a vertical sequence of steps. Each step is a card with a two-column
+          interior: icon column (<code>.col-auto</code>, min-width 4rem) and content column
+          (<code>.col.border-start</code>). The last item should omit <code>.pb-3</code>
+          to avoid extra space below the final dot.
+        </p>
+
+        <!-- Standard timeline -->
+        <h2 class="h4 mt-5">Step timeline</h2>
+        <p class="small text-body-secondary">
+          Used for process flows like "How it works." Constrain width with
+          <code>col-md-8</code> or similar — full-width timelines look too spread out.
+        </p>
+        <div class="row justify-content-center mb-4">
+          <div class="col-12 col-md-8">
+            <ul class="timeline mb-0">
+              <li class="timeline-item pb-3">
+                <div class="card">
+                  <div class="row g-0 align-items-center">
+                    <div class="col-auto p-3 text-center">
+                      <i class="fa-solid fa-bars-progress fa-2x" aria-hidden="true"></i>
+                    </div>
+                    <div class="col border-start p-3">
+                      <h3 class="h5 mb-1">Scan</h3>
+                      <p class="small text-body-secondary mb-0">We fully scan your website.</p>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="timeline-item pb-3">
+                <div class="card">
+                  <div class="row g-0 align-items-center">
+                    <div class="col-auto p-3 text-center">
+                      <i class="fa-solid fa-list-check fa-2x" aria-hidden="true"></i>
+                    </div>
+                    <div class="col border-start p-3">
+                      <h3 class="h5 mb-1">Tasks</h3>
+                      <p class="small text-body-secondary mb-0">We create a prioritized tasklist of items to fix.</p>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="timeline-item pb-3">
+                <div class="card">
+                  <div class="row g-0 align-items-center">
+                    <div class="col-auto p-3 text-center">
+                      <i class="fa-solid fa-screwdriver-wrench fa-2x" aria-hidden="true"></i>
+                    </div>
+                    <div class="col border-start p-3">
+                      <h3 class="h5 mb-1">Fix</h3>
+                      <p class="small text-body-secondary mb-0">Fix issues with your team, agency, or vendor.</p>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="timeline-item">
+                <div class="card">
+                  <div class="row g-0 align-items-center">
+                    <div class="col-auto p-3 text-center">
+                      <i class="fa-solid fa-eye fa-2x" aria-hidden="true"></i>
+                    </div>
+                    <div class="col border-start p-3">
+                      <h3 class="h5 mb-1">Monitor</h3>
+                      <p class="small text-body-secondary mb-0">We continuously monitor for new issues.</p>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <pre class="border rounded p-3 small mb-5"><code>&lt;ul class="timeline mb-0"&gt;
+  &lt;li class="timeline-item pb-3"&gt;
+    &lt;div class="card"&gt;
+      &lt;div class="row g-0 align-items-center"&gt;
+        &lt;div class="col-auto p-3 text-center"&gt;
+          &lt;i class="fa-solid fa-bars-progress fa-2x" aria-hidden="true"&gt;&lt;/i&gt;
+        &lt;/div&gt;
+        &lt;div class="col border-start p-3"&gt;
+          &lt;h3 class="h5 mb-1"&gt;Step title&lt;/h3&gt;
+          &lt;p class="small text-body-secondary mb-0"&gt;Step description.&lt;/p&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/li&gt;
+  &lt;!-- Last item: omit pb-3 --&gt;
+  &lt;li class="timeline-item"&gt;...&lt;/li&gt;
+&lt;/ul&gt;</code></pre>
+
+        <!-- Domain changelog variant -->
+        <h2 class="h4 mt-5">Changelog variant</h2>
+        <p class="small text-body-secondary">
+          For scan history or changelog entries use <code>.timeline-domain</code> and
+          <code>.timeline-date</code> helper classes (both defined in <code>scangov.css</code>).
+          No card wrapper needed — simpler list item content.
+        </p>
+        <div class="row justify-content-center mb-4">
+          <div class="col-12 col-md-8">
+            <ul class="timeline mb-0">
+              <li class="timeline-item pb-3">
+                <p class="timeline-domain mb-0">iowa.gov</p>
+                <p class="timeline-date mb-0">June 30, 2026</p>
+                <p class="small text-body-secondary mb-0">Accessibility score improved from C to A.</p>
+              </li>
+              <li class="timeline-item pb-3">
+                <p class="timeline-domain mb-0">hiv.gov</p>
+                <p class="timeline-date mb-0">June 28, 2026</p>
+                <p class="small text-body-secondary mb-0">Security scan completed. 3 new issues found.</p>
+              </li>
+              <li class="timeline-item">
+                <p class="timeline-domain mb-0">example.gov</p>
+                <p class="timeline-date mb-0">June 25, 2026</p>
+                <p class="small text-body-secondary mb-0">Site added to monitoring.</p>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <pre class="border rounded p-3 small"><code>&lt;ul class="timeline mb-0"&gt;
+  &lt;li class="timeline-item pb-3"&gt;
+    &lt;p class="timeline-domain mb-0"&gt;domain.gov&lt;/p&gt;
+    &lt;p class="timeline-date mb-0"&gt;June 30, 2026&lt;/p&gt;
+    &lt;p class="small text-body-secondary mb-0"&gt;Change description.&lt;/p&gt;
+  &lt;/li&gt;
+&lt;/ul&gt;</code></pre>
+
+      </div>
+    </div>
+  </div>
+</main>
+
+</body>
+</html>

--- a/public/templates/toasts.html
+++ b/public/templates/toasts.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Toasts &amp; loading – ScanGov components</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+  <link rel="stylesheet" href="../css/scangov.css">
+</head>
+<body>
+
+<nav class="navbar navbar-expand-md border-bottom">
+  <div class="container-fluid">
+    <a class="navbar-brand small" href="index.html">
+      <i class="fa-solid fa-bars-progress me-1" aria-hidden="true"></i>
+      ScanGov
+    </a>
+  </div>
+</nav>
+
+<main id="main-content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12 col-md-10 col-lg-8 py-3">
+
+        <h1 class="display-6">Toasts &amp; loading</h1>
+        <p class="text-body-secondary">
+          Patterns for communicating in-progress and completed actions to users.
+          All use proper ARIA attributes so screen readers announce them without focus movement.
+        </p>
+
+        <!-- Spinner -->
+        <h2 class="h4 mt-5">Spinner (block)</h2>
+        <p class="small text-body-secondary">
+          Use <code>.spinner-border</code> with <code>role="status"</code> and a
+          <code>.visually-hidden</code> label for screen readers. Pair with
+          <code>aria-busy="true"</code> on the loading container when replacing content.
+        </p>
+        <div class="mb-3 d-flex gap-3 align-items-center">
+          <div class="spinner-border" role="status">
+            <span class="visually-hidden">Loading…</span>
+          </div>
+          <div class="spinner-border spinner-border-sm" role="status">
+            <span class="visually-hidden">Loading…</span>
+          </div>
+        </div>
+        <pre class="border rounded p-3 small mb-5"><code>&lt;div class="spinner-border" role="status"&gt;
+  &lt;span class="visually-hidden"&gt;Loading…&lt;/span&gt;
+&lt;/div&gt;
+
+&lt;!-- Small variant --&gt;
+&lt;div class="spinner-border spinner-border-sm" role="status"&gt;
+  &lt;span class="visually-hidden"&gt;Loading…&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+
+        <!-- Icon spin (inline) -->
+        <h2 class="h4 mt-5">Icon spin (inline / button)</h2>
+        <p class="small text-body-secondary">
+          For buttons that trigger an async action, swap the button's icon to a spinning
+          <code>fa-spinner fa-spin</code> while the action is pending. Restore the original
+          icon on completion. Don't disable the button unless necessary — prefer visual
+          feedback only.
+        </p>
+        <div class="mb-3 d-flex gap-3 align-items-center">
+          <button class="btn btn-primary" disabled>
+            <i class="fa-solid fa-spinner fa-spin me-2" aria-hidden="true"></i>Scanning…
+          </button>
+          <button class="btn btn-primary">
+            <i class="fa-solid fa-rotate-right me-2" aria-hidden="true"></i>Re-scan
+          </button>
+        </div>
+        <pre class="border rounded p-3 small mb-5"><code>&lt;!-- Pending state --&gt;
+&lt;button class="btn btn-primary" disabled&gt;
+  &lt;i class="fa-solid fa-spinner fa-spin me-2" aria-hidden="true"&gt;&lt;/i&gt;Scanning…
+&lt;/button&gt;
+
+&lt;!-- Idle state --&gt;
+&lt;button class="btn btn-primary"&gt;
+  &lt;i class="fa-solid fa-rotate-right me-2" aria-hidden="true"&gt;&lt;/i&gt;Re-scan
+&lt;/button&gt;</code></pre>
+
+        <!-- Toast notifications -->
+        <h2 class="h4 mt-5">Toast notifications</h2>
+        <p class="small text-body-secondary">
+          Use Bootstrap's <code>.toast</code> component for non-blocking status messages.
+          Always include <code>role="alert" aria-live="assertive" aria-atomic="true"</code>
+          so screen readers announce the message immediately. Position with
+          <code>.position-fixed .bottom-0 .end-0</code> for the standard bottom-right placement.
+          Auto-dismiss after 5 seconds via <code>data-bs-delay="5000" data-bs-autohide="true"</code>.
+        </p>
+        <div class="position-relative" style="height: 120px;">
+          <div class="toast show position-absolute bottom-0 end-0 m-3"
+               role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="toast-header">
+              <i class="fa-solid fa-circle-check text-success me-2" aria-hidden="true"></i>
+              <strong class="me-auto">Done</strong>
+              <button type="button" class="btn-close" aria-label="Close"></button>
+            </div>
+            <div class="toast-body small">
+              Scan complete for iowa.gov.
+            </div>
+          </div>
+        </div>
+        <div class="position-relative mb-4" style="height: 120px;">
+          <div class="toast show position-absolute bottom-0 end-0 m-3"
+               role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="toast-header">
+              <i class="fa-solid fa-circle-xmark text-danger me-2" aria-hidden="true"></i>
+              <strong class="me-auto">Error</strong>
+              <button type="button" class="btn-close" aria-label="Close"></button>
+            </div>
+            <div class="toast-body small">
+              Could not reach iowa.gov. Try again.
+            </div>
+          </div>
+        </div>
+        <pre class="border rounded p-3 small"><code>&lt;!-- Mount inside a .position-fixed.bottom-0.end-0.p-3 container --&gt;
+&lt;div class="toast" role="alert" aria-live="assertive" aria-atomic="true"
+     data-bs-autohide="true" data-bs-delay="5000"&gt;
+  &lt;div class="toast-header"&gt;
+    &lt;i class="fa-solid fa-circle-check text-success me-2" aria-hidden="true"&gt;&lt;/i&gt;
+    &lt;strong class="me-auto"&gt;Done&lt;/strong&gt;
+    &lt;button type="button" class="btn-close" aria-label="Close"&gt;&lt;/button&gt;
+  &lt;/div&gt;
+  &lt;div class="toast-body small"&gt;Scan complete for domain.gov.&lt;/div&gt;
+&lt;/div&gt;
+
+&lt;script&gt;
+// Initialize and show
+const el = document.querySelector('.toast');
+const toast = new bootstrap.Toast(el);
+toast.show();
+&lt;/script&gt;</code></pre>
+
+      </div>
+    </div>
+  </div>
+</main>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Eleven live reference pages covering the non-obvious scangov.css and Bootstrap conventions used across ScanGov sites. Each page is a standalone static HTML file with labeled examples and explanatory notes for use as a copy-from reference on new builds and future my.scangov cleanup: badges (grade/score color mapping, WCAG hex reference, status icons), breadcrumbs (default vs. profile-style hierarchy), buttons (outline auto-margin-top behavior, btn-primary-outline scoping), cards (stretched-link and status variants), forms (inputs, search, checkboxes, file upload, validation), nav-tabs (topnav/filter/pills and icon color system), sidebar (sticky list-group layout, horizontal), tables (existing, now linked from index), timeline (step flow and changelog variants), and toasts/loading (spinner, icon spin, Bootstrap toast with ARIA). index.html serves as a discoverable directory for all patterns.