### PR TITLE
#418 Add form CSS: form-group, form-error, required indicator spacing…

### DIFF
--- a/public/css/scangov.css
+++ b/public/css/scangov.css
@@ -1375,8 +1375,29 @@ a.card {
 
 /* Forms */
 
-form {
-    padding-bottom: 2rem;
+form button[type="submit"],
+form input[type="submit"] {
+    margin-bottom: 2rem;
+}
+
+td form button[type="submit"],
+td form input[type="submit"] {
+    margin-bottom: 0;
+}
+
+.form-group {
+    margin-bottom: 1rem;
+}
+
+.form-label .fa-asterisk {
+    margin-left: 0.25rem;
+}
+
+.form-error {
+    color: var(--bs-danger);
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+    display: none;
 }
 
 .form-control {


### PR DESCRIPTION
Closes #418

## Add form standards CSS (2026-07-05)

- Replaced `form { padding-bottom: 2rem }` with `form button[type="submit"] { margin-bottom: 2rem }` — scopes spacing to the submit button
- Added `td form button[type="submit"] { margin-bottom: 0 }` — resets margin for table-cell action forms
- Added `.form-group { margin-bottom: 1rem }` — semantic field wrapper class
- Added `.form-label .fa-asterisk { margin-left: 0.25rem }` — spacing for required field indicator
- Added `.form-error` — hidden validation error message styling