### PR TITLE
Overhaul light-mode icon and UI colors

### DIFF
--- a/public/css/scangov.css
+++ b/public/css/scangov.css
@@ -121,11 +121,11 @@
     --bs-form-control-focus-color: var(--bs-body-color);
     --bs-card-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
     /* Status colors */
-    --bs-success: #70e17b;
-    --bs-success-rgb: 112, 225, 123;
-    --bs-bg-success: #70e17b;
-    --bs-bg-success-rgb: 112, 225, 123;
-    --bs-border-success: #70e17b;
+    --bs-success: #7e9c1d;
+    --bs-success-rgb: 126, 156, 29;
+    --bs-bg-success: #7e9c1d;
+    --bs-bg-success-rgb: 126, 156, 29;
+    --bs-border-success: #7e9c1d;
     --bs-warning: #face00;
     --bs-warning-rgb: 250, 206, 0;
     --bs-text-warning: #000000;
@@ -207,15 +207,24 @@
     --bs-form-control-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
     --bs-form-control-focus-color: var(--bs-body-color);
     --bs-card-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
-    /* font vars, status colors inherited from :root */
+    /* font vars inherited from :root; danger/warning status colors also inherited
+       since they don't change between themes - only success differs here */
+    --bs-success: #7fb135;
+    --bs-success-rgb: 127, 177, 53;
+    --bs-bg-success: #7fb135;
+    --bs-bg-success-rgb: 127, 177, 53;
+    --bs-border-success: #7fb135;
+    --bs-success-bg-subtle: #c5ee93;
 }
 
 /* Status badge overrides */
 
-/* WCAG 2.2 AA: #13171f on #70e17b = 8.19:1 ✓ */
+/* WCAG 2.2 AA: #13171f on #7e9c1d (dark) = 5.69:1 ✓, #13171f on #7fb135 (light) = 4.65:1 ✓
+   background-color pulls from the theme's --bs-success-rgb (same source .bg-success uses)
+   so the plain and text utilities never drift apart across themes. */
 .text-bg-success {
     color: #13171f !important;
-    background-color: #70e17b !important;
+    background-color: rgba(var(--bs-success-rgb), var(--bs-bg-opacity, 1)) !important;
 }
 
 /* WCAG 2.2 AA: #000 on #face00 = 15.18:1 ✓ */
@@ -224,10 +233,12 @@
     background-color: #face00 !important;
 }
 
-/* WCAG 2.2 AA: #fff on #e41d3d = 4.73:1 ✓ */
+/* WCAG 2.2 AA: #fff on #e41d3d = 4.73:1 ✓ - rgba(...) here matches the progress
+   bar's plain .bg-danger, which already uses Bootstrap's own --bs-danger-rgb-based
+   background rather than a flat hex, so card and progress-bar reds stay identical. */
 .text-bg-danger {
     color: #ffffff !important;
-    background-color: #e41d3d !important;
+    background-color: rgba(var(--bs-danger-rgb), var(--bs-bg-opacity, 1)) !important;
 }
 
 .text-bg-primary {
@@ -449,9 +460,7 @@ button:not(.card *) {
 }
 
 .navbar {
-    box-shadow: var(--bs-shadow);
-    transition: box-shadow 0.25s ease;
-    --bs-navbar-padding-y: 0.5rem;
+    --bs-navbar-padding-y: 0.25rem;
     --bs-navbar-padding-x: 0;
     --bs-nav-link-padding-y: 0.5rem;
     --bs-nav-link-padding-x: 1rem;
@@ -464,6 +473,7 @@ button:not(.card *) {
     display: flex;
     align-items: center;
     gap: 0.25rem;
+    margin-right: 0;
 }
 
 .navbar-brand>svg {
@@ -476,6 +486,24 @@ button:not(.card *) {
 
 .navbar-brand:hover>svg {
     fill: var(--bs-link-color) !important;
+}
+
+.navbar-brand-container {
+    display: flex;
+    align-items: center;
+}
+
+.navbar-org {
+    font-family: var(--bs-font-monospace);
+    color: var(--bs-body-color) !important;
+    text-decoration: none;
+    margin-left: 0.5rem;
+    padding-left: 0.5rem;
+    border-left: 1px solid var(--bs-border-color);
+}
+
+.navbar-org:hover {
+    color: var(--bs-link-color) !important;
 }
 
 .navbar-toggler-icon {
@@ -557,6 +585,10 @@ a.list-group-item:hover {
     text-decoration: none;
 }
 
+.bc-domain-name {
+    font-family: "JetBrains Mono ExtraBold", monospace !important;
+}
+
 .breadcrumb-profile .breadcrumb-item,
 .breadcrumb-profile .breadcrumb-item a,
 .breadcrumb-profile .breadcrumb-item a:visited {
@@ -598,6 +630,12 @@ a.list-group-item:hover {
 [data-bs-theme=light] .breadcrumb-item a.bc-org-current,
 [data-bs-theme=light] .breadcrumb-item a.bc-org-current:visited {
     color: var(--bs-body-color);
+}
+
+.breadcrumb-item a.bc-domain:hover,
+[data-bs-theme=light] .breadcrumb-item a.bc-domain:hover {
+    color: var(--bs-link-color) !important;
+    text-decoration: none;
 }
 
 /* Default (Bootstrap-style) breadcrumb — no bold, standard colors */
@@ -726,17 +764,12 @@ button.btn-primary-outline {
     opacity: 0;
     pointer-events: none;
     visibility: hidden;
-    background-color: var(--bs-primary);
-    color: var(--bs-primary-text) !important;
-    border-radius: var(--bs-border-radius);
-    border: 1px solid var(--bs-primary);
+    background-color: var(--bs-body-bg) !important;
     box-shadow: var(--bs-shadow);
     cursor: pointer;
-    font-family: var(--bs-font-bold);
     position: fixed;
     bottom: 1rem;
-    left: 50%;
-    transform: translateX(-50%);
+    right: 1rem;
     z-index: 1000;
     text-decoration: none;
     transition: opacity 0.25s ease, visibility 0.25s ease, filter 0.25s ease, box-shadow 0.25s ease;
@@ -748,19 +781,33 @@ button.btn-primary-outline {
     visibility: visible;
 }
 
-.btn-primary i, .btn-primary svg,
-.feedback i, .feedback svg {
+.btn-primary i, .btn-primary svg {
     color: inherit !important;
     transition: filter 0.25s ease;
 }
 
-.btn-primary:hover, .btn-primary:focus, .btn-primary:active,
-.feedback:hover, .feedback:focus, .feedback:active {
+.btn.feedback i, .btn.feedback svg {
+    color: var(--bs-primary) !important;
+    transition: filter 0.25s ease;
+}
+
+.btn-primary:hover, .btn-primary:focus, .btn-primary:active {
     filter: brightness(1.3);
     box-shadow: var(--bs-box-shadow-md);
     background-color: var(--bs-primary) !important;
     color: var(--bs-primary-text) !important;
     border-color: var(--bs-primary) !important;
+}
+
+.feedback:hover, .feedback:focus, .feedback:active {
+    background-color: var(--bs-body-color) !important;
+    box-shadow: var(--bs-box-shadow-md);
+}
+
+.btn.feedback:hover i, .btn.feedback:hover svg,
+.btn.feedback:focus i, .btn.feedback:focus svg,
+.btn.feedback:active i, .btn.feedback:active svg {
+    color: var(--bs-btn-hover-color) !important;
 }
 
 .btn-primary-outline:not(.active):hover,
@@ -1028,6 +1075,49 @@ button.btn-primary-outline {
 
 .nav-tabs.topnav .nav-link.active:hover {
     filter: brightness(1.3);
+}
+
+/* Light mode: active/selected nav states use body text color (black) instead of the
+   link/primary blue - sidebar, nav-pills, and tabs all read as "selected" via a solid
+   black fill rather than brand color. Text/icon color stays var(--bs-primary-text)
+   (white in light mode), which still contrasts fine against black. */
+[data-bs-theme=light] .nav-pills .nav-link.active,
+[data-bs-theme=light] .nav-pills .nav-link.active:focus,
+[data-bs-theme=light] .nav-pills .nav-link.active:hover,
+[data-bs-theme=light] .nav-pills a.btn-primary-outline.active,
+[data-bs-theme=light] .nav-pills a.btn-primary-outline.active:focus,
+[data-bs-theme=light] .nav-pills a.btn-primary-outline.active:hover {
+    background-color: var(--bs-body-color) !important;
+    border-color: var(--bs-body-color) !important;
+}
+
+[data-bs-theme=light] .list-group-item.active,
+[data-bs-theme=light] .list-group-item.active:focus,
+[data-bs-theme=light] .list-group-item.active:hover {
+    background-color: var(--bs-body-color) !important;
+    border-color: var(--bs-body-color) !important;
+}
+
+[data-bs-theme=light] .nav-tabs.filter .nav-link.active,
+[data-bs-theme=light] .nav-tabs.filter .nav-link.active:focus {
+    background-color: var(--bs-body-color) !important;
+    border-color: var(--bs-body-color) !important;
+}
+
+[data-bs-theme=light] .nav-tabs.topnav .nav-link.active,
+[data-bs-theme=light] .nav-tabs.topnav .nav-link.active:focus {
+    background-color: var(--bs-body-color) !important;
+    border-color: var(--bs-body-color) !important;
+}
+
+/* Form submit buttons only - other .btn-primary uses (links styled as buttons,
+   feedback CTA, etc.) keep the brand blue. */
+[data-bs-theme=light] button[type="submit"].btn-primary,
+[data-bs-theme=light] button[type="submit"].btn-primary:hover,
+[data-bs-theme=light] button[type="submit"].btn-primary:focus,
+[data-bs-theme=light] button[type="submit"].btn-primary:active {
+    background-color: var(--bs-body-color) !important;
+    border-color: var(--bs-body-color) !important;
 }
 
 /* Per-icon colors (dark mode default) */
@@ -1366,7 +1456,7 @@ a.card {
 /* Status cards — consistent across themes */
 
 .text-bg-success.card {
-    border-color: #70e17b !important;
+    border-color: var(--bs-success) !important;
 }
 
 .text-bg-warning.card {
@@ -1374,14 +1464,26 @@ a.card {
 }
 
 .text-bg-danger.card {
-    border-color: #e41d3d !important;
+    border-color: var(--bs-danger) !important;
+}
+
+.text-bg-info.card {
+    border-color: #0dcaf0 !important;
 }
 
 .text-bg-success.card:hover,
 .text-bg-warning.card:hover,
-.text-bg-danger.card:hover {
+.text-bg-danger.card:hover,
+.text-bg-info.card:hover {
     filter: brightness(1.3);
     box-shadow: var(--bs-box-shadow-md);
+}
+
+[data-bs-theme=light] .text-bg-success.card:hover,
+[data-bs-theme=light] .text-bg-warning.card:hover,
+[data-bs-theme=light] .text-bg-danger.card:hover,
+[data-bs-theme=light] .text-bg-info.card:hover {
+    border-color: var(--bs-border-color) !important;
 }
 
 /* Icons and links inside status cards match card text color */
@@ -1399,13 +1501,22 @@ a.card {
     fill: #ffffff !important;
 }
 
-.text-bg-success .card-header,
-.text-bg-warning .card-header,
-.text-bg-danger .card-header {
-    background-color: rgba(255, 255, 255, 0.15) !important;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.2) !important;
+/* Padding/font applies to every grade-style card header, colored or not (e.g. the
+   uncolored "Add new site" card on /sites), so they all line up consistently. The
+   tinted background/border-bottom below stays scoped to colored variants only, since
+   it's a white overlay meant to sit on top of a color. */
+.card-grade .card-header,
+.card-grade-sm .card-header {
     padding: 0.75rem 1rem;
     font-family: var(--bs-font-regular);
+}
+
+.text-bg-success .card-header,
+.text-bg-warning .card-header,
+.text-bg-danger .card-header,
+.text-bg-info .card-header {
+    background-color: rgba(255, 255, 255, 0.15) !important;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.2) !important;
     --bs-card-cap-bg: rgba(255, 255, 255, 0.15);
 }
 
@@ -1428,6 +1539,12 @@ a.card {
     padding-bottom: 2.5rem;
 }
 
+.card-grade .card-body .display-1,
+.card-body.text-center .display-1 {
+    line-height: 1;
+    margin-bottom: 0;
+}
+
 .card-grade-sm .card-body {
     text-align: center;
     padding-top: 1.25rem;
@@ -1435,6 +1552,7 @@ a.card {
 }
 
 .card-grade-sm .card-body .display-2 {
+    line-height: 1;
     margin-bottom: 0;
 }
 
@@ -2105,6 +2223,13 @@ td a:hover .fa-circle-info {
     color: var(--bs-body-color) !important;
 }
 
+/* Sidenav link hover comes before the icon-color rules below so those rules -
+   same specificity, but later in source - keep winning on hover, instead of the
+   icons flashing link-color like the surrounding link text does. */
+.js-sidenav a:hover {
+    color: var(--bs-link-color) !important;
+}
+
 .js-sidenav a .fa-circle-question,
 .js-sidenav a:hover .fa-circle-question {
     color: #97d4ea !important;
@@ -2472,341 +2597,60 @@ a .fa-up-right-from-square {
     color: #ffbc78 !important;
 }
 
-/* Icons — light mode overrides (WCAG 2.2 AA compliant, min 4.5:1 on #fff) */
+/* Icons — light mode: inherit surrounding text color instead of individual accent colors.
+   Excludes icons that carry their own Bootstrap text-color utility (e.g. the sidebar's
+   pass/fail status dots, .text-success/.text-danger up/down changelog arrows) - those are
+   semantic status color, not decorative icon color, and must keep winning. */
 
-[data-bs-theme=light] .fa-arrow-right-to-bracket,
-[data-bs-theme=light] .fa-arrows-rotate,
-[data-bs-theme=light] .fa-compact-disc,
-[data-bs-theme=light] .fa-building,
-[data-bs-theme=light] .fa-check-circle,
-[data-bs-theme=light] .fa-circle-check,
-[data-bs-theme=light] .fa-circle-info,
-[data-bs-theme=light] .fa-circle-plus,
-[data-bs-theme=light] .fa-puzzle-piece,
-[data-bs-theme=light] .fa-right-from-bracket,
-[data-bs-theme=light] .fa-rotate,
-[data-bs-theme=light] .fa-seedling,
-[data-bs-theme=light] .fa-toggle-on {
-    /* → #2d7a3a = 5.31:1 ✓ */
-    color: #2d7a3a !important;
-}
-
-[data-bs-theme=light] .fa-bell,
-[data-bs-theme=light] .fa-copy,
-[data-bs-theme=light] .fa-diagram-project,
-[data-bs-theme=light] .fa-envelope-open-text,
-[data-bs-theme=light] .fa-graduation-cap,
-[data-bs-theme=light] .fa-link,
-[data-bs-theme=light] .fa-ranking-star,
-[data-bs-theme=light] .fa-table,
-[data-bs-theme=light] .fa-table-columns,
-[data-bs-theme=light] .fa-up-right-from-square {
-    /* → #0d7a6e = 5.22:1 ✓ */
-    color: #0d7a6e !important;
-}
-
-[data-bs-theme=light] .fa-expand {
-    /* → #0a6ebd = 5.28:1 ✓ */
-    color: #0a6ebd !important;
-}
-
-[data-bs-theme=light] .fa-terminal {
-    /* → #147a5f = 5.28:1 ✓ */
-    color: #147a5f !important;
-}
-
-[data-bs-theme=light] .fa-bell-concierge,
-[data-bs-theme=light] .fa-brain,
-[data-bs-theme=light] .fa-bug,
-[data-bs-theme=light] .fa-code-branch,
-[data-bs-theme=light] .fa-concierge-bell,
-[data-bs-theme=light] .fa-face-frown,
-[data-bs-theme=light] .fa-life-ring,
-[data-bs-theme=light] .fa-map,
-[data-bs-theme=light] .fa-server {
-    /* → #8a5e2d = 5.65:1 ✓ */
-    color: #8a5e2d !important;
-}
-
-[data-bs-theme=light] .fa-bolt,
-[data-bs-theme=light] .fa-broom,
-[data-bs-theme=light] .fa-certificate,
-[data-bs-theme=light] .fa-check,
-[data-bs-theme=light] .fa-crown,
-[data-bs-theme=light] .fa-dolly,
-[data-bs-theme=light] .fa-dove,
-[data-bs-theme=light] .fa-face-grin-hearts,
-[data-bs-theme=light] .fa-face-sad-tear,
-[data-bs-theme=light] .fa-face-smile,
-[data-bs-theme=light] .fa-file-contract,
-[data-bs-theme=light] .fa-hand, [data-bs-theme=light] .fa-hands,
-[data-bs-theme=light] .fa-key,
-[data-bs-theme=light] .fa-hands-clapping,
-[data-bs-theme=light] .fa-handshake,
-[data-bs-theme=light] .fa-handshake-simple,
-[data-bs-theme=light] .fa-handshake-angle,
-[data-bs-theme=light] .fa-hand-peace,
-[data-bs-theme=light] .fa-hand-point-up,
-[data-bs-theme=light] .fa-hand-point-down,
-[data-bs-theme=light] .fa-hand-point-right,
-[data-bs-theme=light] .fa-hand-point-left,
-[data-bs-theme=light] .fa-highlighter,
-[data-bs-theme=light] .fa-lightbulb,
-[data-bs-theme=light] .fa-message,
-[data-bs-theme=light] .fa-magnifying-glass,
-[data-bs-theme=light] .fa-magnifying-glass-chart,
-[data-bs-theme=light] .fa-plug-circle-bolt,
-[data-bs-theme=light] .fa-robot,
-[data-bs-theme=light] .fa-scale-balanced,
-[data-bs-theme=light] .fa-scroll,
-[data-bs-theme=light] .fa-star,
-[data-bs-theme=light] .fa-stop-circle,
-[data-bs-theme=light] .fa-wand-magic-sparkles,
-[data-bs-theme=light] .fa-wand-sparkles {
-    /* → #8a6500 = 5.33:1 ✓ */
-    color: #8a6500 !important;
-}
-
-[data-bs-theme=light] .fa-arrow-right-arrow-left,
-[data-bs-theme=light] .fa-asterisk {
-    /* → #8a6500 on #fff = 5.33:1 ✓ */
-    color: #8a6500 !important;
-}
-
-[data-bs-theme=light] .fa-bars-progress,
-[data-bs-theme=light] .fa-chart-simple,
-[data-bs-theme=light] .fa-chart-line,
-[data-bs-theme=light] .fa-circle-exclamation,
-[data-bs-theme=light] .fa-dashboard,
-[data-bs-theme=light] .fa-fire,
-[data-bs-theme=light] .fa-folder-tree,
-[data-bs-theme=light] .fa-gauge,
-[data-bs-theme=light] .fa-gauge-simple,
-[data-bs-theme=light] .fa-gauge-high,
-[data-bs-theme=light] .fa-rss,
-[data-bs-theme=light] .fa-screwdriver-wrench,
-[data-bs-theme=light] .fa-sitemap {
-    /* → #8a4f00 = 6.56:1 ✓ */
-    color: #8a4f00 !important;
-}
-
-[data-bs-theme=light] .btn.btn-outline-primary .fa-sitemap {
-    color: #8a4f00 !important;
-}
-
-[data-bs-theme=light] .btn.btn-outline-primary:hover .fa-sitemap,
-[data-bs-theme=light] .btn.btn-outline-primary:focus .fa-sitemap {
+/* Font-glyph <i> icons: color is all that's needed to render the glyph, and "inherit"
+   (rather than a hardcoded value) lets icons inside colored contexts - like a button's
+   own white text - pick up their parent's color instead of being forced black. */
+[data-bs-theme=light] .fa-solid:not([class*="text-"]),
+[data-bs-theme=light] .fa-regular:not([class*="text-"]),
+[data-bs-theme=light] .fa-brands:not([class*="text-"]) {
     color: inherit !important;
 }
 
-[data-bs-theme=light] .btn.btn-outline-primary .fa-wand-sparkles {
-    color: #8a6500 !important;
+/* svg/use icons (as opposed to <i> font-glyph icons) render from a <symbol> defined
+   once in the hidden sprite sheet (svgsprites.mjs) and cloned via <use> at each call
+   site. Browsers differ on whether currentColor for that clone resolves against the
+   symbol's own class list or the call site's wrapping <svg class="fa-solid ...">, so
+   both are set explicitly (not "inherit", an actual value) to cover either resolution
+   path regardless of engine. */
+[data-bs-theme=light] symbol[data-prefix="fas"]:not([class*="text-"]),
+[data-bs-theme=light] symbol[data-prefix="far"]:not([class*="text-"]),
+[data-bs-theme=light] symbol[data-prefix="fab"]:not([class*="text-"]) {
+    color: var(--bs-body-color) !important;
+    fill: var(--bs-body-color) !important;
 }
 
-[data-bs-theme=light] .btn.btn-outline-primary:hover .fa-wand-sparkles,
-[data-bs-theme=light] .btn.btn-outline-primary:focus .fa-wand-sparkles {
-    color: inherit !important;
+/* Exceptions to the inherit-text-color rule above: these keep a fixed, meaningful color
+   regardless of theme rather than blending into surrounding text. Selectors here need to
+   match the blanket rule's specificity (three class-tier selectors) to win - a plain
+   type selector or combinator isn't enough to beat it, since specificity compares the
+   class/attribute tier first regardless of how many type selectors are added. */
+[data-bs-theme=light] .fa-solid.fa-heart {
+    color: #e41d3d !important;
 }
 
-[data-bs-theme=light] .btn.btn-outline-primary .fa-file-lines {
-    color: #1a6fa0 !important;
+[data-bs-theme=light] .bg-secondary-subtle {
+    color: var(--bs-body-color) !important;
+    background-color: #ffffff !important;
 }
 
-[data-bs-theme=light] .btn.btn-outline-primary:hover .fa-file-lines,
-[data-bs-theme=light] .btn.btn-outline-primary:focus .fa-file-lines {
-    color: inherit !important;
+[data-bs-theme=light] .breadcrumb-item .fa-solid:not([class*="text-"]) {
+    color: var(--bs-body-color) !important;
 }
 
-[data-bs-theme=light] .btn.btn-outline-primary .fa-rocket {
-    color: #5b4ea0 !important;
+/* Light-mode-specific card colors - the Tasks/info card differs from its dark-mode
+   value here, unlike red/yellow/green (green now via --bs-success-rgb above) which
+   stay consistent through variables rather than a separate override block. */
+[data-bs-theme=light] .text-bg-info {
+    background-color: #58b4ff !important;
 }
 
-[data-bs-theme=light] .btn.btn-outline-primary:hover .fa-rocket,
-[data-bs-theme=light] .btn.btn-outline-primary:focus .fa-rocket {
-    color: inherit !important;
-}
-
-[data-bs-theme=light] .fa-arrow-right,
-[data-bs-theme=light] .fa-arrow-right-long,
-[data-bs-theme=light] .fa-book-open,
-[data-bs-theme=light] .fa-book-open-reader,
-[data-bs-theme=light] .fa-truck-ramp-box,
-[data-bs-theme=light] .fa-calendar,
-[data-bs-theme=light] .fa-circle-nodes,
-[data-bs-theme=light] .fa-download,
-[data-bs-theme=light] .fa-envelope,
-[data-bs-theme=light] .fa-file,
-[data-bs-theme=light] .fa-file-lines,
-[data-bs-theme=light] .fa-file-arrow-down,
-[data-bs-theme=light] .fa-file-csv,
-[data-bs-theme=light] .fa-file-code,
-[data-bs-theme=light] .fa-markdown,
-[data-bs-theme=light] .fa-linkedin,
-[data-bs-theme=light] .fa-linkedin-in,
-[data-bs-theme=light] .fa-x-twitter,
-[data-bs-theme=light] .fa-paper-plane,
-[data-bs-theme=light] .fa-percent,
-[data-bs-theme=light] .fa-list-check,
-[data-bs-theme=light] .fa-satellite-dish,
-[data-bs-theme=light] .fa-square-check,
-[data-bs-theme=light] .fa-universal-access {
-    /* → #1a6fa0 = 5.49:1 ✓ */
-    color: #1a6fa0 !important;
-}
-
-[data-bs-theme=light] .fa-binoculars,
-[data-bs-theme=light] .fa-circle-play,
-[data-bs-theme=light] .fa-eye {
-    /* → #1a7a6a = 5.21:1 ✓ */
-    color: #1a7a6a !important;
-}
-
-[data-bs-theme=light] .fa-bluesky,
-[data-bs-theme=light] .fa-code,
-[data-bs-theme=light] .fa-bullhorn,
-[data-bs-theme=light] .fa-discord,
-[data-bs-theme=light] .fa-github,
-[data-bs-theme=light] .fa-user-group,
-[data-bs-theme=light] .fa-wave-square {
-    /* → #4a6bb5 = 5.17:1 ✓ */
-    color: #4a6bb5 !important;
-}
-
-[data-bs-theme=light] .fa-comment,
-[data-bs-theme=light] .fa-comments,
-[data-bs-theme=light] .fa-filter,
-[data-bs-theme=light] .fa-print,
-[data-bs-theme=light] .fa-rocket {
-    /* → #5b4ea0 = 6.90:1 ✓ */
-    color: #5b4ea0 !important;
-}
-
-[data-bs-theme=light] .feedback .fa-rocket,
-[data-bs-theme=light] .feedback .fa-message {
-    color: inherit !important;
-}
-
-[data-bs-theme=light] .fa-circle-notch {
-    /* → #5a5a5a = 6.90:1 ✓ */
-    color: #5a5a5a !important;
-}
-
-[data-bs-theme=light] .fa-circle-question {
-    /* → #1a6fa0 = 5.49:1 ✓ */
-    color: #1a6fa0;
-}
-
-[data-bs-theme=light] a .fa-circle-question,
-[data-bs-theme=light] a:hover .fa-circle-question,
-[data-bs-theme=light] a .fa-circle-info,
-[data-bs-theme=light] a:hover .fa-circle-info {
-    color: inherit !important;
-}
-
-[data-bs-theme=light] .js-sidenav a .fa-circle-question,
-[data-bs-theme=light] .js-sidenav a:hover .fa-circle-question {
-    color: #1a6fa0 !important;
-}
-
-[data-bs-theme=light] .js-sidenav a .fa-circle-info,
-[data-bs-theme=light] .js-sidenav a:hover .fa-circle-info {
-    color: #2d7a3a !important;
-}
-
-[data-bs-theme=light] .fa-triangle-exclamation {
-    /* → #b03030 = 5.62:1 ✓ */
-    color: #b03030;
-}
-
-[data-bs-theme=light] .fa-box-archive,
-[data-bs-theme=light] .fa-file-pdf,
-[data-bs-theme=light] .fa-filter-circle-xmark,
-[data-bs-theme=light] .fa-rectangle-list,
-[data-bs-theme=light] .fa-share-from-square,
-[data-bs-theme=light] .fa-user-astronaut {
-    /* → #b5476a = 5.15:1 ✓ */
-    color: #b5476a !important;
-}
-
-[data-bs-theme=light] .fa-circle-down,
-[data-bs-theme=light] .fa-circle-xmark,
-[data-bs-theme=light] .fa-flag {
-    /* → #b52040 = 6.47:1 ✓ */
-    color: #b52040 !important;
-}
-
-[data-bs-theme=light] .fa-circle-up {
-    /* → #1a7a2a = 5.10:1 ✓ */
-    color: #1a7a2a !important;
-}
-
-[data-bs-theme=light] .fa-building-columns,
-[data-bs-theme=light] .fa-circle-dot,
-[data-bs-theme=light] .fa-gear,
-[data-bs-theme=light] .fa-gears,
-[data-bs-theme=light] .fa-network-wired,
-[data-bs-theme=light] .fa-newspaper {
-    /* → #1a5e9e = 6.69:1 ✓ */
-    color: #1a5e9e !important;
-}
-
-[data-bs-theme=light] .fa-heart,
-[data-bs-theme=light] .fa-heart-crack,
-[data-bs-theme=light] .fa-lock,
-[data-bs-theme=light] .fa-shield-halved {
-    /* → #c0392b = 5.44:1 ✓ */
-    color: #c0392b !important;
-}
-
-[data-bs-theme=light] .fa-house {
-    /* → #7a2ea0 = 7.70:1 ✓ */
-    color: #7a2ea0 !important;
-}
-
-[data-bs-theme=light] .fa-laptop {
-    /* → #1a6e6a = 6.03:1 ✓ */
-    color: #1a6e6a !important;
-}
-
-[data-bs-theme=light] .fa-landmark {
-    /* → #1a5e9e = 6.69:1 ✓ */
-    color: #1a5e9e !important;
-}
-
-[data-bs-theme=light] .fa-share-nodes,
-[data-bs-theme=light] .fa-check-to-slot,
-[data-bs-theme=light] .fa-timeline {
-    /* → #9e2060 = 7.42:1 ✓ */
-    color: #9e2060 !important;
-}
-
-[data-bs-theme=light] .fa-database {
-    /* → #0d6b52 = 7.3:1 ✓ */
-    color: #0d6b52 !important;
-}
-
-[data-bs-theme=light] .fa-arrow-pointer,
-[data-bs-theme=light] .fa-hand-pointer,
-[data-bs-theme=light] .fa-mastodon,
-[data-bs-theme=light] .fa-photo-film,
-[data-bs-theme=light] .fa-spray-can-sparkles {
-    /* → #6b3fa0 = 7.38:1 ✓ */
-    color: #6b3fa0 !important;
-}
-
-[data-bs-theme=light] .fa-user-shield {
-    /* → #8a4e00 = 6.62:1 ✓ */
-    color: #8a4e00 !important;
-}
-
-[data-bs-theme=light] .fa-window-maximize {
-    /* → #a03050 = 6.92:1 ✓ */
-    color: #a03050 !important;
-}
-
-[data-bs-theme=light] .fa-youtube {
-    /* → #c0392b = 5.44:1 ✓ */
-    color: #c0392b !important;
+[data-bs-theme=light] .text-bg-info.card {
+    border-color: #58b4ff !important;
 }
 
 /* Status card icons — must come last to beat FA light mode overrides */
@@ -2996,10 +2840,6 @@ th a:focus i, th a:focus svg {
     top: 1rem;
 }
 
-.js-sidenav a:hover {
-    color: var(--bs-link-color) !important;
-}
-
 /* Actions list: separate boxes — restore left border + full radius on every item */
 .actions.list-group .list-group-item {
     padding: 0;
@@ -3047,10 +2887,6 @@ th a:focus i, th a:focus svg {
 /* Search no-results icon */
 .fa-signs-post {
     color: #ffbe2e;
-}
-
-[data-bs-theme=light] .fa-signs-post {
-    color: #8a6500 !important;
 }
 
 /* Lunr search results */
@@ -3301,6 +3137,7 @@ body[data-bs-theme='dark'] ul.navbar-nav img {
 
 .card-footer {
   color: inherit !important;
+  font-family: var(--bs-font-monospace);
 }
 
 a.cardlink {
@@ -3374,6 +3211,12 @@ td.padded-cell {
 
 [data-bs-theme=dark] .form-select.js-subfilters {
   --bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e")
+}
+
+[data-bs-theme=light] .form-select.js-subfilters {
+  background-color: var(--bs-body-color);
+  color: var(--bs-body-bg);
+  --bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23ffffff' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e")
 }
 
 blockquote .lead {


### PR DESCRIPTION
Replace per-icon light-mode color overrides with a blanket text-color rule plus targeted exceptions (heart, breadcrumb domain, status cards). Fix SVG sprite icons (About tab bolt/question/warning/certificate/scroll) not picking up the text-color rule due to how <use>-referenced <symbol> content resolves currentColor across browsers.

Also:
- Active/selected nav states (sidebar, nav-pills, tabs) and form submit buttons use body text color instead of link/primary blue in light mode
- Feedback button restyled as btn-outline-primary with a colored icon, correct hover state (black bg, white text/icon)
- Navbar: org name added next to brand (monospace, equal spacing)
- Grade/score/task cards: symmetric padding, black hover border reverted to normal border color, background pulls from CSS vars instead of hardcoded hex so .bg-* and .text-bg-* never drift apart
- Standards filter dropdown: black background, white caret in light mode
- Breadcrumb domain: bold monospace, link-color hover without underline