### PR TITLE
Add .text-neutral-icon utility for decorative status icons

### DIFF
--- a/public/css/scangov.css
+++ b/public/css/scangov.css
@@ -2727,6 +2727,15 @@ a .fa-up-right-from-square {
     fill: var(--bs-danger) !important;
 }
 
+/* Opt-out marker for a status icon used decoratively (e.g. a "Risks" card label,
+   not an actual warning state) - excludes it from the light-mode rule above via
+   the "text-" substring match, without forcing a color in dark mode too, so the
+   icon's normal (non-light-mode) default color is untouched there. */
+[data-bs-theme=light] .text-neutral-icon {
+    color: var(--bs-body-color) !important;
+    fill: var(--bs-body-color) !important;
+}
+
 [data-bs-theme=light] .bg-secondary-subtle {
     color: var(--bs-body-color) !important;
     background-color: #ffffff !important;


### PR DESCRIPTION
fa-triangle-exclamation (and similar status icons) render red/danger in light mode by default, meant for real pass/fail status contexts. The Risks card icon on /indicators/*/ pages uses the same icon decoratively, not as a status indicator, so it picked up that red color unintentionally. text-neutral-icon opts a specific instance out via the light-mode rule's existing text- exclusion, without touching its dark-mode color.