### PR TITLE
Fix theme reverting to dark on Eleventy dev-server live-reload

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -69,7 +69,20 @@
     {% include "favicon.html" %}
     {% include "style.html" %}
     <script>
-        document.documentElement.setAttribute('data-bs-theme', window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        (function () {
+            var syncTheme = function () {
+                var desired = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                if (document.documentElement.getAttribute('data-bs-theme') !== desired) {
+                    document.documentElement.setAttribute('data-bs-theme', desired);
+                }
+            };
+            syncTheme();
+            window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', syncTheme);
+            new MutationObserver(syncTheme).observe(document.documentElement, {
+                attributes: true,
+                attributeFilter: ['data-bs-theme']
+            });
+        })();
     </script>
 </head>
 

--- a/_includes/js.html
+++ b/_includes/js.html
@@ -2,15 +2,6 @@
 <script src="/js/tablesort-vendor.js"></script>
 <script src="/js/tablesort-init.js"></script>
 <script>
-  const setTheme = (dark) => {
-    document.body.setAttribute('data-bs-theme', dark ? 'dark' : 'light');
-  };
-  const darkQuery = window.matchMedia("(prefers-color-scheme: dark)");
-  const lightQuery = window.matchMedia("(prefers-color-scheme: light)");
-  setTheme(!lightQuery.matches);
-  darkQuery.addEventListener('change', e => setTheme(e.matches));
-</script>
-<script>
   const toggler = document.querySelector('button.navbar-toggler');
   if (toggler) {
     toggler.addEventListener('click', function(e) {


### PR DESCRIPTION
The dev server's DOM-morph reload strips the data-bs-theme attribute (matchRootAttributes syncs <html> to the freshly server-rendered HTML, which never has this client-only attribute). Consolidate the theme script into a self-healing version: sets theme on load, re-syncs on OS change, and adds a MutationObserver that restores the attribute the instant anything strips it. Removes the now-redundant duplicate matchMedia listener from js.html.