### PR TITLE
#575 Add canonical transactional email reference template

### DIFF
--- a/public/templates/email.html
+++ b/public/templates/email.html
@@ -1,0 +1,62 @@
+<!--
+  Canonical transactional email template used across ScanGov apps
+  (currently consumed via my.scangov.com/src/shared/emailtemplate.mjs).
+
+  This file is the raw, unwrapped output an email client renders — it is
+  intentionally NOT wrapped in the site nav/Bootstrap frame like the other
+  templates in this directory, since inbox clients strip external
+  stylesheets and only respect inline styles / table layout. Open this
+  file directly in a browser to see exactly what a recipient sees.
+
+  Rules for reuse:
+  - Table-based layout, all styles inline (no <link>, no <style> blocks
+    beyond the color-scheme meta tags below).
+  - Force light mode via the meta tags — many mail clients (Apple Mail
+    especially) auto-invert unstyled dark-mode-unaware markup, which
+    reads worse than a deliberate light-only email.
+  - 600px max-width container, 1px #e5e7eb border, 8px border-radius.
+  - Logo pulled from the hosted brand asset (docs.scangov.org), not a
+    local/relative path, since emails have no build-time asset pipeline.
+  - One primary CTA button per email (#2563eb, ScanGov's light-mode
+    --bs-primary), rendered as a table cell background, not a plain <a>,
+    for Outlook compatibility.
+-->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light">
+<meta name="supported-color-scheme" content="light">
+<title>Finish setting up your ScanGov account 🚀</title>
+</head>
+<body style="margin:0; padding:0; background-color:#f4f6f8;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f6f8;">
+    <tr>
+      <td align="center" style="padding:32px 16px;">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px; width:100%; background-color:#ffffff; border:1px solid #e5e7eb; border-radius:8px;">
+          <tr>
+            <td align="center" style="padding:32px 32px 16px;">
+              <img src="https://docs.scangov.org/assets/brand/logo-light.png" width="140" alt="ScanGov" style="display:block; width:140px; max-width:140px; height:auto; border:0;">
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:8px 40px 32px; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:16px; line-height:1.6; color:#13171f;">
+              <h1 style="margin:0 0 16px; font-size:20px; font-weight:600; color:#13171f;">Finish setting up your ScanGov account 🚀</h1>
+              <p style="margin:0 0 16px;">Hi! You're almost there — click below to verify your email and get into your account.</p>
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin:24px 0 8px;">
+                <tr>
+                  <td style="border-radius:6px; background-color:#2563eb;">
+                    <a href="https://my.scangov.com/signup?email=you%40example.com&hash=sample&time=0" style="display:inline-block; padding:12px 28px; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; font-size:15px; font-weight:600; color:#ffffff; text-decoration:none; border-radius:6px;">Verify email</a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:24px 0 0; font-size:13px; color:#6b7280;">Didn't request this? You can ignore this email.</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/public/templates/index.html
+++ b/public/templates/index.html
@@ -132,6 +132,15 @@
             </div>
           </div>
 
+          <div class="col-12 col-md-6">
+            <div class="card">
+              <div class="card-body">
+                <h2 class="h5"><a href="email.html" class="stretched-link">Transactional email</a></h2>
+                <p class="card-text small text-body-secondary">Raw, inlined-style HTML email template (not wrapped in this page's frame) — open directly to see what recipients see.</p>
+              </div>
+            </div>
+          </div>
+
         </div>
 
       </div>


### PR DESCRIPTION
Documents the inline-styled table-layout email design used by my.scangov.com's new HTML transactional emails.